### PR TITLE
'Updated AL-Go System Files'

### DIFF
--- a/.AL-Go/cloudDevEnv.ps1
+++ b/.AL-Go/cloudDevEnv.ps1
@@ -1,4 +1,4 @@
-#
+﻿#
 # Script for creating cloud development environment
 # Please do not modify this script as it will be auto-updated from the AL-Go Template
 # Recommended approach is to use as is or add a script (freddyk-devenv.ps1), which calls this script with the user specific parameters
@@ -12,43 +12,25 @@ Param(
 $ErrorActionPreference = "stop"
 Set-StrictMode -Version 2.0
 
-$pshost = Get-Host
-if ($pshost.Name -eq "Visual Studio Code Host") {
-    $executionPolicy = Get-ExecutionPolicy -Scope CurrentUser
-    Write-Host "Execution Policy is $executionPolicy"
-    if ($executionPolicy -eq "Restricted") {
-        Write-Host "Changing Execution Policy to RemoteSigned"
-        Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
-    }
-    if ($MyInvocation.InvocationName -eq '.' -or $MyInvocation.Line -eq '') {
-        $scriptName = Join-Path $PSScriptRoot $MyInvocation.MyCommand
-    }
-    else {
-        $scriptName = $MyInvocation.InvocationName
-    }
-    if (Test-Path -Path $scriptName -PathType Leaf) {
-        $scriptName = (Get-Item -path $scriptName).FullName
-        $pslink = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Windows PowerShell\Windows PowerShell.lnk"
-        if (!(Test-Path $pslink)) {
-            $pslink = "powershell.exe"
-        }
-        Start-Process -Verb runas $pslink @("-Command ""$scriptName"" -fromVSCode -environmentName '$environmentName' -reuseExistingEnvironment `$$reuseExistingEnvironment")
-        return
-    }
-}
-
 try {
-$ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
 $webClient = New-Object System.Net.WebClient
 $webClient.CachePolicy = New-Object System.Net.Cache.RequestCachePolicy -argumentList ([System.Net.Cache.RequestCacheLevel]::NoCacheNoStore)
 $webClient.Encoding = [System.Text.Encoding]::UTF8
+Write-Host "Downloading GitHub Helper module"
+$GitHubHelperPath = "$([System.IO.Path]::GetTempFileName()).psm1"
+$webClient.DownloadFile('https://raw.githubusercontent.com/businesscentralapps/tmp54nzkP-Actions/main/Github-Helper.psm1', $GitHubHelperPath)
 Write-Host "Downloading AL-Go Helper script"
-$webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v2.1/AL-Go-Helper.ps1', $ALGoHelperPath)
+$ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
+$webClient.DownloadFile('https://raw.githubusercontent.com/businesscentralapps/tmp54nzkP-Actions/main/AL-Go-Helper.ps1', $ALGoHelperPath)
+
+Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local
 
-$baseFolder = Join-Path $PSScriptRoot ".." -Resolve
+$baseFolder = GetBaseFolder -folder $PSScriptRoot
+$project = GetProject -baseFolder $baseFolder -projectALGoFolder $PSScriptRoot
 
 Clear-Host
+Write-Host
 Write-Host -ForegroundColor Yellow @'
    _____ _                 _   _____             ______            
   / ____| |               | | |  __ \           |  ____|           
@@ -70,7 +52,7 @@ if (Test-Path (Join-Path $PSScriptRoot "NewBcContainer.ps1")) {
     Write-Host -ForegroundColor Red "WARNING: The project has a NewBcContainer override defined. Typically, this means that you cannot run a cloud development environment"
 }
 
-$settings = ReadSettings -baseFolder $baseFolder -userName $env:USERNAME
+$settings = ReadSettings -baseFolder $baseFolder -project $project -userName $env:USERNAME
 
 Write-Host
 
@@ -78,10 +60,11 @@ if (-not $environmentName) {
     $environmentName = Enter-Value `
         -title "Environment name" `
         -question "Please enter the name of the environment to create" `
-        -default "$($env:USERNAME)-sandbox"
+        -default "$($env:USERNAME)-sandbox" `
+        -trimCharacters @('"',"'",' ')
 }
 
-if (-not $PSBoundParameters.ContainsKey('reuseExistingEnvironment')) {
+if ($PSBoundParameters.Keys -notcontains 'reuseExistingEnvironment') {
     $reuseExistingEnvironment = (Select-Value `
         -title "What if the environment already exists?" `
         -options @{ "Yes" = "Reuse existing environment"; "No" = "Recreate environment" } `
@@ -94,7 +77,8 @@ CreateDevEnv `
     -caller local `
     -environmentName $environmentName `
     -reuseExistingEnvironment:$reuseExistingEnvironment `
-    -baseFolder $baseFolder
+    -baseFolder $baseFolder `
+    -project $project
 }
 catch {
     Write-Host -ForegroundColor Red "Error: $($_.Exception.Message)`nStacktrace: $($_.scriptStackTrace)"

--- a/.AL-Go/localdevenv.ps1
+++ b/.AL-Go/localdevenv.ps1
@@ -1,3 +1,144 @@
+﻿#
+# Script for creating local development environment
+# Please do not modify this script as it will be auto-updated from the AL-Go Template
+# Recommended approach is to use as is or add a script (freddyk-devenv.ps1), which calls this script with the user specific parameters
+#
+Param(
+    [string] $containerName = "",
+    [string] $auth = "",
+    [pscredential] $credential = $null,
+    [string] $licenseFileUrl = "",
+    [string] $insiderSasToken = "",
+    [switch] $fromVSCode
+)
 
+$ErrorActionPreference = "stop"
+Set-StrictMode -Version 2.0
 
-# Dummy comment
+try {
+$webClient = New-Object System.Net.WebClient
+$webClient.CachePolicy = New-Object System.Net.Cache.RequestCachePolicy -argumentList ([System.Net.Cache.RequestCacheLevel]::NoCacheNoStore)
+$webClient.Encoding = [System.Text.Encoding]::UTF8
+Write-Host "Downloading GitHub Helper module"
+$GitHubHelperPath = "$([System.IO.Path]::GetTempFileName()).psm1"
+$webClient.DownloadFile('https://raw.githubusercontent.com/businesscentralapps/tmp54nzkP-Actions/main/Github-Helper.psm1', $GitHubHelperPath)
+Write-Host "Downloading AL-Go Helper script"
+$ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
+$webClient.DownloadFile('https://raw.githubusercontent.com/businesscentralapps/tmp54nzkP-Actions/main/AL-Go-Helper.ps1', $ALGoHelperPath)
+
+Import-Module $GitHubHelperPath
+. $ALGoHelperPath -local
+
+$baseFolder = GetBaseFolder -folder $PSScriptRoot
+$project = GetProject -baseFolder $baseFolder -projectALGoFolder $PSScriptRoot
+
+Clear-Host
+Write-Host
+Write-Host -ForegroundColor Yellow @'
+  _                     _   _____             ______            
+ | |                   | | |  __ \           |  ____|           
+ | |     ___   ___ __ _| | | |  | | _____   __ |__   _ ____   __
+ | |    / _ \ / __/ _` | | | |  | |/ _ \ \ / /  __| | '_ \ \ / /
+ | |____ (_) | (__ (_| | | | |__| |  __/\ V /| |____| | | \ V / 
+ |______\___/ \___\__,_|_| |_____/ \___| \_/ |______|_| |_|\_/  
+                                                                
+'@
+
+Write-Host @'
+This script will create a docker based local development environment for your project.
+
+NOTE: You need to have Docker installed, configured and be able to create Business Central containers for this to work.
+If this fails, you can setup a cloud based development environment by running cloudDevEnv.ps1
+
+All apps and test apps will be compiled and published to the environment in the development scope.
+The script will also modify launch.json to have a Local Sandbox configuration point to your environment.
+
+'@
+
+$settings = ReadSettings -baseFolder $baseFolder -project $project -userName $env:USERNAME
+
+Write-Host "Checking System Requirements"
+$dockerProcess = (Get-Process "dockerd" -ErrorAction Ignore)
+if (!($dockerProcess)) {
+    Write-Host -ForegroundColor Red "Dockerd process not found. Docker might not be started, not installed or not running Windows Containers."
+}
+if ($settings.keyVaultName) {
+    if (-not (Get-Module -ListAvailable -Name 'Az.KeyVault')) {
+        Write-Host -ForegroundColor Red "A keyvault name is defined in Settings, you need to have the Az.KeyVault PowerShell module installed (use Install-Module az) or you can set the keyVaultName to an empty string in the user settings file ($($ENV:UserName).settings.json)."
+    }
+}
+
+Write-Host
+
+if (-not $containerName) {
+    $containerName = Enter-Value `
+        -title "Container name" `
+        -question "Please enter the name of the container to create" `
+        -default "bcserver" `
+        -trimCharacters @('"',"'",' ')
+}
+
+if (-not $auth) {
+    $auth = Select-Value `
+        -title "Authentication mechanism for container" `
+        -options @{ "Windows" = "Windows Authentication"; "UserPassword" = "Username/Password authentication" } `
+        -question "Select authentication mechanism for container" `
+        -default "UserPassword"
+}
+
+if (-not $credential) {
+    if ($auth -eq "Windows") {
+        $credential = Get-Credential -Message "Please enter your Windows Credentials" -UserName $env:USERNAME
+        $CurrentDomain = "LDAP://" + ([ADSI]"").distinguishedName
+        $domain = New-Object System.DirectoryServices.DirectoryEntry($CurrentDomain,$credential.UserName,$credential.GetNetworkCredential().password)
+        if ($null -eq $domain.name) {
+            Write-Host -ForegroundColor Red "Unable to verify your Windows Credentials, you might not be able to authenticate to your container"
+        }
+    }
+    else {
+        $credential = Get-Credential -Message "Please enter username and password for your container" -UserName "admin"
+    }
+}
+
+if (-not $licenseFileUrl) {
+    if ($settings.type -eq "AppSource App") {
+        $description = "When developing AppSource Apps, your local development environment needs the developer licensefile with permissions to your AppSource app object IDs"
+        $default = ""
+    }
+    else {
+        $description = "When developing PTEs, you can optionally specify a developer licensefile with permissions to object IDs of your dependant apps"
+        $default = "none"
+    }
+
+    $licenseFileUrl = Enter-Value `
+        -title "LicenseFileUrl" `
+        -description $description `
+        -question "Local path or a secure download URL to license file " `
+        -default $default `
+        -doNotConvertToLower `
+        -trimCharacters @('"',"'",' ')
+}
+
+if ($licenseFileUrl -eq "none") {
+    $licenseFileUrl = ""
+}
+
+CreateDevEnv `
+    -kind local `
+    -caller local `
+    -containerName $containerName `
+    -baseFolder $baseFolder `
+    -project $project `
+    -auth $auth `
+    -credential $credential `
+    -licenseFileUrl $licenseFileUrl `
+    -insiderSasToken $insiderSasToken
+}
+catch {
+    Write-Host -ForegroundColor Red "Error: $($_.Exception.Message)`nStacktrace: $($_.scriptStackTrace)"
+}
+finally {
+    if ($fromVSCode) {
+        Read-Host "Press ENTER to close this window"
+    }
+}

--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -1,5 +1,5 @@
-{
-  "type": "AppSource App",
-  "templateUrl": "https://github.com/microsoft/AL-Go-AppSource@v2.1",
-  "MicrosoftTelemetryConnectionString": ""
+﻿{
+    "type":  "AppSource App",
+    "templateUrl":  "https://github.com/businesscentralapps/tmp54nzkP-AppSource@main",
+    "MicrosoftTelemetryConnectionString":  ""
 }

--- a/.github/RELEASENOTES.copy.md
+++ b/.github/RELEASENOTES.copy.md
@@ -1,6 +1,189 @@
-## Preview
+﻿## Preview
 
 Note that when using the preview version of AL-Go for GitHub, you need to Update your AL-Go system files, as soon as possible when told to do so.
+
+### Issues
+
+Issue 542 Deploy Workflow fails
+
+### New Settings
+- `keyVaultCodesignCertificateName`:  With this setting you can delegate the codesigning to an Azure Key Vault. This can be useful if your certificate has to be stored in a Hardware Security Module
+
+## v3.1
+
+### Issues
+
+Issue #446 Wrong NewLine character in Release Notes
+Issue #453 DeliverToStorage - override fails reading secrets
+Issue #434 Use gh auth token to get authentication token instead of gh auth status
+Issue #501 The Create New App action will now use 22.0.0.0 as default application reference and include NoImplicitwith feature.
+
+
+### New behavior
+
+The following workflows:
+
+- Create New App
+- Create New Test App
+- Create New Performance Test App
+- Increment Version Number
+- Add Existing App
+- Create Online Development Environment
+
+All these actions now uses the selected branch in the **Run workflow** dialog as the target for the Pull Request or Direct COMMIT.
+
+### New Settings
+
+- `UseCompilerFolder`: Setting useCompilerFolder to true causes your pipelines to use containerless compiling. Unless you also set `doNotPublishApps` to true, setting useCompilerFolder to true won't give you any performance advantage, since AL-Go for GitHub will still need to create a container in order to publish and test the apps. In the future, publishing and testing will be split from building and there will be other options for getting an instance of Business Central for publishing and testing. 
+- `vsixFile`: vsixFile should be a direct download URL to the version of the AL Language extension you want to use for building the project or repo. By default, AL-Go will use the AL Language extension that comes with the Business Central Artifacts.
+
+### New Workflows
+
+- **_BuildALGoProject** is a reusable workflow that unites the steps for building an AL-Go projects. It has been reused in the following workflows: _CI/CD_, _Pull Request Build_, _NextMinor_, _NextMajor_ and _Current_.
+The workflow appears under the _Actions_ tab in GitHub, but it is not actionable in any way.  
+
+### New Actions
+
+- **DetermineArtifactUrl** is used to determine which artifacts to use for building a project in CI/CD, PullRequestHandler, Current, NextMinor and NextMajor workflows.
+
+### License File
+
+With the changes to the CRONUS license in Business Central version 22, that license can in most cases be used as a developer license for AppSource Apps and it is no longer mandatory to specify a license file in AppSource App repositories.
+Obviously, if you build and test your app for Business Central versions prior to 21, it will fail if you don't specify a licenseFileUrl secret.
+
+## v3.0
+
+### **NOTE:** When upgrading to this version
+When upgrading to this version form earlier versions of AL-Go for GitHub, you will need to run the _Update AL-Go System Files_ workflow twice if you have the `useProjectDependencies` setting set to _true_.
+
+### Publish to unknown environment
+You can now run the **Publish To Environment** workflow without creating the environment in GitHub or settings up-front, just by specifying the name of a single environment in the Environment Name when running the workflow.
+Subsequently, if an AuthContext secret hasn't been created for this environment, the Device Code flow authentication will be initiated from the Publish To Environment workflow and you can publish to the new environment without ever creating a secret.
+Open Workflow details to get the device Code for authentication in the job summary for the initialize job.
+
+### Create Online Dev. Environment
+When running the **Create Online Dev. Environment** workflow without having the _adminCenterApiCredentials_ secret created, the workflow will intiate the deviceCode flow and allow you to authenticate to the Business Central Admin Center.
+Open Workflow details to get the device Code for authentication in the job summary for the initialize job.
+
+### Issues
+- Issue #391 Create release action - CreateReleaseBranch error
+- Issue 434 Building local DevEnv, downloading dependencies: Authentication fails when using "gh auth status"
+
+### Changes to Pull Request Process
+In v2.4 and earlier, the PullRequestHandler would trigger the CI/CD workflow to run the PR build.
+Now, the PullRequestHandler will perform the build and the CI/CD workflow is only run on push (or manual dispatch) and will perform a complete build.
+
+### Build modes per project
+Build modes can now be specified per project
+
+### New Actions
+- **DetermineProjectsToBuild** is used to determine which projects to build in PullRequestHandler, CI/CD, Current, NextMinor and NextMajor workflows.
+- **CalculateArtifactNames** is used to calculate artifact names in PullRequestHandler, CI/CD, Current, NextMinor and NextMajor workflows.
+- **VerifyPRChanges** is used to verify whether a PR contains changes, which are not allowed from a fork.
+
+## v2.4
+
+### Issues
+- Issue #171 create a workspace file when creating a project
+- Issue #356 Publish to AppSource fails in multi project repo
+- Issue #358 Publish To Environment Action stopped working in v2.3
+- Issue #362 Support for EnableTaskScheduler
+- Issue #360 Creating a release and deploying from a release branch
+- Issue #371 'No previous release found' for builds on release branches
+- Issue #376 CICD jobs that are triggered by the pull request trigger run directly to an error if title contains quotes
+
+### Release Branches
+**NOTE:** Release Branches are now only named after major.minor if the patch value is 0 in the release tag (which must be semver compatible)
+
+This version contains a number of bug fixes to release branches, to ensure that the recommended branching strategy is fully supported. Bugs fixed includes:
+- Release branches was named after the full tag (1.0.0), even though subsequent hotfixes released from this branch would be 1.0.x
+- Release branches named 1.0 wasn't picked up as a release branch
+- Release notes contained the wrong changelog
+- The previous release was always set to be the first release from a release branch
+- SemVerStr could not have 5 segments after the dash
+- Release was created on the right SHA, but the release branch was created on the wrong SHA
+
+Recommended branching strategy:
+
+![Branching Strategy](https://raw.githubusercontent.com/microsoft/AL-Go/main/Scenarios/images/branchingstrategy.png)
+
+### New Settings
+New Project setting: EnableTaskScheduler in container executing tests and when setting up local development environment
+
+### Support for GitHub variables: ALGoOrgSettings and ALGoRepoSettings
+Recently, GitHub added support for variables, which you can define on your organization or your repository.
+AL-Go now supports that you can define a GitHub variable called ALGoOrgSettings, which will work for all repositories (with access to the variable)
+Org Settings will be applied before Repo settings and local repository settings files will override values in the org settings
+You can also define a variable called ALGoRepoSettings on the repository, which will be applied after reading the Repo Settings file in the repo
+Example for usage could be setup of branching strategies, versioning or an appDependencyProbingPaths to repositories which all repositories share.
+appDependencyProbingPaths from settings variables are merged together with appDependencyProbingPaths defined in repositories
+
+### Refactoring and tests
+ReadSettings has been refactored to allow organization wide settings to be added as well. CI Tests have been added to cover ReadSettings.
+
+## v2.3
+
+### Issues
+- Issue #312 Branching enhancements
+- Issue #229 Create Release action tags wrong commit
+- Issue #283 Create Release workflow uses deprecated actions
+- Issue #319 Support for AssignPremiumPlan
+- Issue #328 Allow multiple projects in AppSource App repo
+- Issue #344 Deliver To AppSource on finding app.json for the app
+- Issue #345 LocalDevEnv.ps1 can't Dowload the file license file
+
+### New Settings
+New Project setting: AssignPremiumPlan on user in container executing tests and when setting up local development environment
+New Repo setting: unusedALGoSystemFiles is an array of AL-Go System Files, which won't be updated during Update AL-Go System Files. They will instead be removed. Use with care, as this can break the AL-Go for GitHub functionality and potentially leave your repo no longer functional.
+
+### Build modes support
+AL-Go projects can now be built in different modes, by specifying the _buildModes_ setting in AL-Go-Settings.json. Read more about build modes in the [Basic Repository settings](https://github.com/microsoft/AL-Go/blob/main/Scenarios/settings.md#basic-repository-settings).
+
+### LocalDevEnv / CloudDevEnv
+With the support for PowerShell 7 in BcContainerHelper, the scripts LocalDevEnv and CloudDevEnv (placed in the .AL-Go folder) for creating development environments have been modified to run inside VS Code instead of spawning a new powershell 5.1 session.
+
+### Continuous Delivery
+Continuous Delivery can now run from other branches than main. By specifying a property called branches, containing an array of branches in the deliveryContext json construct, the artifacts generated from this branch are also delivered. The branch specification can include wildcards (like release/*). Default is main, i.e. no changes to functionality.
+
+### Continuous Deployment
+Continuous Deployment can now run from other branches than main. By creating a repo setting (.github/AL-Go-Settings.json) called **`<environmentname>-Branches`**, which is an array of branches, which will deploy the generated artifacts to this environment. The branch specification can include wildcards (like release/*), although this probably won't be used a lot in continuous deployment. Default is main, i.e. no changes to functionality.
+
+### Create Release
+When locating artifacts for the various projects, the SHA used to build the artifact is used for the release tag
+If all projects are not available with the same SHA, this error is thrown: **The build selected for release doesn't contain all projects. Please rebuild all projects by manually running the CI/CD workflow and recreate the release.**
+There is no longer a hard dependency on the main branch name from Create Release.
+
+### AL-Go Tests
+Some unit tests have been added and AL-Go unit tests can now be run directly from VS Code.
+Another set of end to end tests have also been added and in the documentation on contributing to AL-Go, you can see how to run these in a local fork or from VS Code.
+
+### LF, UTF8 and JSON
+GitHub natively uses LF as line seperator in source files.
+In earlier versions of AL-Go for GitHub, many scripts and actions would use CRLF and convert back and forth. Some files were written with UTF8 BOM (Byte Order Mark), other files without and JSON formatting was done using PowerShell 5.1 (which is different from PowerShell 7).
+In the latest version, we always use LF as line seperator, UTF8 without BOM and JSON files are written using PowerShell 7. If you have self-hosted runners, you need to ensure that PS7 is installed to make this work.
+
+### Experimental Support
+Setting the repo setting "shell" to "pwsh", followed by running Update AL-Go System Files, will cause all PowerShell code to be run using PowerShell 7 instead of PowerShell 5. This functionality is experimental. Please report any issues at https://github.com/microsoft/AL-Go/issues
+Setting the repo setting "runs-on" to "Ubuntu-Latest", followed by running Update AL-Go System Files, will cause all non-build jobs to run using Linux. This functionality is experimental. Please report any issues at https://github.com/microsoft/AL-Go/issues
+
+## v2.2
+
+### Enhancements
+- Container Event log is added as a build artifact if builds or tests are failing
+
+### Issues
+- Issue #280 Overflow error when test result summary was too big
+- Issue #282, 292 AL-Go for GitHub causes GitHub to issue warnings
+- Issue #273 Potential security issue in Pull Request Handler in Open Source repositories
+- Issue #303 PullRequestHandler fails on added files
+- Issue #299 Multi-project repositories build all projects on Pull Requests
+- Issue #291 Issues with new Pull Request Handler 
+- Issue #287 AL-Go pipeline fails in ReadSettings step
+
+### Changes
+- VersioningStrategy 1 is no longer supported. GITHUB_ID has changed behavior (Issue #277)
+
+## v2.1
 
 ### Issues
 - Issue #233 AL-Go for GitHub causes GitHub to issue warnings

--- a/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -1,4 +1,6 @@
-name: 'Add existing app or test app'
+﻿name: 'Add existing app or test app'
+
+run-name: "Add existing app or test app in [${{ github.ref_name }}]"
 
 on:
   workflow_dispatch:
@@ -21,7 +23,11 @@ permissions:
 
 defaults:
   run:
-    shell: PowerShell
+    shell: powershell
+
+env:
+  ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
+  ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
 
 jobs:
   AddExistingAppOrTestApp:
@@ -32,13 +38,15 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/WorkflowInitialize@main
         with:
+          shell: powershell
           eventId: "DO0090"
 
       - name: Add existing app
-        uses: microsoft/AL-Go-Actions/AddExistingApp@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/AddExistingApp@main
         with:
+          shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           project: ${{ github.event.inputs.project }}
           url: ${{ github.event.inputs.url }}
@@ -46,7 +54,8 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/WorkflowPostProcess@main
         with:
+          shell: powershell
           eventId: "DO0090"
           telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}

--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -1,182 +1,150 @@
-name: ' CI/CD'
+﻿name: ' CI/CD'
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: ["Pull Request Handler"]
-    types:
-      - completed
   push:
     paths-ignore:
-      - 'README.md'
-      - '.github/**'
+      - '**.md'
+      - '.github/workflows/*.yaml'
+      - '!.github/workflows/CICD.yaml'
     branches: [ 'main', 'release/*', 'feature/*' ]
+
+defaults:
+  run:
+    shell: powershell
 
 permissions:
   contents: read
   actions: read
-  pull-requests: write
-  checks: write
 
-defaults:
-  run:
-    shell: PowerShell
+env:
+  workflowDepth: 1
+  ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
+  ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
 
 jobs:
   Initialization:
-    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: [ windows-latest ]
-    env:
-      workflowDepth: 0
     outputs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
       settings: ${{ steps.ReadSettings.outputs.SettingsJson }}
-      projects: ${{ steps.ReadSettings.outputs.ProjectsJson }}
-      projectCount: ${{ steps.ReadSettings.outputs.ProjectCount }}
       environments: ${{ steps.ReadSettings.outputs.EnvironmentsJson }}
       environmentCount: ${{ steps.ReadSettings.outputs.EnvironmentCount }}
       deliveryTargets: ${{ steps.DetermineDeliveryTargets.outputs.DeliveryTargetsJson }}
       deliveryTargetCount: ${{ steps.DetermineDeliveryTargets.outputs.DeliveryTargetCount }}
       githubRunner: ${{ steps.ReadSettings.outputs.GitHubRunnerJson }}
+      githubRunnerShell: ${{ steps.ReadSettings.outputs.GitHubRunnerShell }}
       checkRunId: ${{ steps.CreateCheckRun.outputs.checkRunId }}
-      projectDependenciesJson: ${{ steps.ReadSettings.outputs.ProjectDependenciesJson }}
-      buildOrderJson: ${{ steps.ReadSettings.outputs.BuildOrderJson }}
-      buildOrderDepth: ${{ steps.ReadSettings.outputs.BuildOrderDepth }}
+      projects: ${{ steps.determineProjectsToBuild.outputs.ProjectsJson }}
+      projectDependenciesJson: ${{ steps.determineProjectsToBuild.outputs.ProjectDependenciesJson }}
+      buildOrderJson: ${{ steps.determineProjectsToBuild.outputs.BuildOrderJson }}
+      workflowDepth: ${{ steps.DetermineWorkflowDepth.outputs.WorkflowDepth }}
     steps:
-      - name: Create CI/CD Workflow Check Run
-        id: CreateCheckRun
-        if: github.event_name == 'workflow_run'
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            var details_url = context.serverUrl.concat('/',context.repo.owner,'/',context.repo.repo,'/actions/runs/',context.runId)
-            var response = await github.rest.checks.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: 'CI/CD Workflow',
-              head_sha: '${{ github.event.workflow_run.head_sha }}',
-              status: 'queued',
-              details_url: details_url,
-              output: {
-                title: 'CI/CD Workflow',
-                summary: '[Workflow Details]('.concat(details_url,')')
-              }
-            });
-            core.setOutput('checkRunId', response.data.id);
-
       - name: Checkout
         uses: actions/checkout@v3
-
-      - name: 'Download Pull Request Changes'
-        if: github.event_name == 'workflow_run'
-        uses: actions/github-script@v6
         with:
-          script: |
-            var run_id = Number('${{ github.event.workflow_run.id }}');
-            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: run_id
-            });
-            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == 'Pull_Request_Files'
-            })[0];
-            var download = await github.rest.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
-               archive_format: 'zip'
-            });
-            var fs = require('fs');
-            fs.writeFileSync('.PullRequestChanges.zip', Buffer.from(download.data));
-
-      - name: Apply Pull Request Changes
-        if: github.event_name == 'workflow_run'
-        run: |
-          $ErrorActionPreference = "STOP"
-          $location = (Get-Location).path
-          $prfolder = '.PullRequestChanges'
-          Expand-Archive -Path ".\$prfolder.zip" -DestinationPath ".\$prfolder"
-          Remove-Item -Path ".\$prfolder.zip" -force
-          Get-ChildItem -Path $prfolder -Recurse -File | ForEach-Object {
-            $path = $_.FullName
-            $deleteFile = $path.EndsWith('.REMOVE')
-            if ($deleteFile) {
-              $path = $path.SubString(0,$path.Length-7)
-            }
-            $newPath = $path.Replace("$prfolder\","")
-            $newFolder = [System.IO.Path]::GetDirectoryName($newPath)
-            $extension = [System.IO.Path]::GetExtension($path)
-            $filename = [System.IO.Path]::GetFileName($path)
-            if ('${{ github.event.workflow_run.head_repository.full_name }}' -ne $ENV:GITHUB_REPOSITORY) {
-              if ($extension -eq '.ps1' -or $extension -eq '.yaml' -or $extension -eq '.yml' -or $filename -eq "CODEOWNERS") {
-                throw "Pull Request containing changes to scripts, workflows or CODEOWNERS are not allowed from forks."
-              }
-            }
-            if ($deleteFile) {
-              if (Test-Path $newPath) {
-                Write-Host "Removing $newPath"
-                Remove-Item $newPath -Force
-              }
-              else {
-                Write-Host "$newPath was already deleted"
-              }
-            }
-            else {
-              if (-not (Test-Path $newFolder)) {
-                New-Item $newFolder -ItemType Directory | Out-Null
-              }
-              Write-Host "Copying $path to $newFolder"
-              Copy-Item $path -Destination $newFolder -Force
-            }
-          }
+          lfs: true
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/WorkflowInitialize@main
         with:
+          shell: powershell
           eventId: "DO0091"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/ReadSettings@main
         with:
+          shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
-          getProjects: 'Y'
           getEnvironments: '*'
 
+      - name: Determine Workflow Depth
+        id: DetermineWorkflowDepth
+        run: |
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "WorkflowDepth=$($env:workflowDepth)"
+          
+      - name: Determine Projects To Build
+        id: determineProjectsToBuild
+        uses: businesscentralapps/tmp54nzkP-Actions/DetermineProjectsToBuild@main
+        with:
+          shell: powershell
+          maxBuildDepth: ${{ env.workflowDepth }}
+
+      - name: Determine Delivery Target Secrets
+        id: DetermineDeliveryTargetSecrets
+        run: |
+          $ErrorActionPreference = "STOP"
+          Set-StrictMode -version 2.0
+          $deliveryTargetSecrets = @('GitHubPackagesContext','NuGetContext','StorageContext','AppSourceContext')
+          $namePrefix = 'DeliverTo'
+          Get-Item -Path (Join-Path $ENV:GITHUB_WORKSPACE ".github/$($namePrefix)*.ps1") | ForEach-Object {
+            $deliveryTarget = [System.IO.Path]::GetFileNameWithoutExtension($_.Name.SubString($namePrefix.Length))
+            $deliveryTargetSecrets += @("$($deliveryTarget)Context")
+          }
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "Secrets=$($deliveryTargetSecrets -join ',')"
+
       - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/ReadSecrets@main
         env:
           secrets: ${{ toJson(secrets) }}
         with:
+          shell: powershell
           settingsJson: ${{ env.Settings }}
-          secrets: 'GitHubPackagesContext,NuGetContext,StorageContext,AppSourceContext'
+          secrets: ${{ steps.DetermineDeliveryTargetSecrets.outputs.Secrets }}
 
       - name: Determine Delivery Targets
         id: DetermineDeliveryTargets
         run: |
           $ErrorActionPreference = "STOP"
-          $deliveryTargets = @()
-          if ($env:StorageContext) {
-            $deliveryTargets += @("Storage")
-          }
-          if ($env:NuGetContext) {
-            $deliveryTargets += @("NuGet")
-          }
-          if ($env:GitHubPackagesContext) {
-            $deliveryTargets += @("GitHubPackages")
-          }
-          if ($env:type -eq "AppSource App" -and $env:AppSourceContinuousDelivery -eq "true") {
-            if ($env:AppSourceContext) {
+          Set-StrictMode -version 2.0
+          $deliveryTargets = @('GitHubPackages','NuGet','Storage')
+          if ($env:type -eq "AppSource App") {
+            $continuousDelivery = $false
+            # For multi-project repositories, we will add deliveryTarget AppSource if any project has AppSourceContinuousDelivery set to true
+            ('${{ steps.determineProjectsToBuild.outputs.ProjectsJson }}' | ConvertFrom-Json) | where-Object { $_ } | ForEach-Object {
+              $projectSettings = Get-Content (Join-Path $_ '.AL-Go/settings.json') -raw | ConvertFrom-Json
+              if ($projectSettings.PSObject.Properties.Name -eq 'AppSourceContinuousDelivery' -and $projectSettings.AppSourceContinuousDelivery) {
+                Write-Host "Project $_ is setup for Continuous Delivery"
+                $continuousDelivery = $true
+              }
+            }
+            if ($continuousDelivery) {
               $deliveryTargets += @("AppSource")
             }
           }
-          Get-Item -Path (Join-Path $ENV:GITHUB_WORKSPACE ".github\DeliverTo*.ps1") | ForEach-Object {
-            $deliveryTargets += @([System.IO.Path]::GetFileNameWithoutExtension($_.Name.SubString(9)))
+          $namePrefix = 'DeliverTo'
+          Get-Item -Path (Join-Path $ENV:GITHUB_WORKSPACE ".github/$($namePrefix)*.ps1") | ForEach-Object {
+            $deliveryTarget = [System.IO.Path]::GetFileNameWithoutExtension($_.Name.SubString($namePrefix.Length))
+            $deliveryTargets += @($deliveryTarget)
           }
-          $deliveryTargets = $deliveryTargets | Select-Object -unique
+          $deliveryTargets = @($deliveryTargets | Select-Object -unique | Where-Object {
+            $include = $false
+            Write-Host "Check DeliveryTarget $_"
+            $contextName = "$($_)Context"
+            $deliveryContext = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String([System.Environment]::GetEnvironmentVariable($contextName)))
+            if ($deliveryContext) {
+              $settingName = "DeliverTo$_"
+              $settings = $env:Settings | ConvertFrom-Json
+              if (($settings.PSObject.Properties.Name -eq $settingName) -and ($settings."$settingName".PSObject.Properties.Name -eq "Branches")) {
+                Write-Host "Branches:"
+                $settings."$settingName".Branches | ForEach-Object {
+                  Write-Host "- $_"
+                  if ($ENV:GITHUB_REF_NAME -like $_) {
+                    $include = $true
+                  }
+                }
+              }
+              else {
+                $include = ($ENV:GITHUB_REF_NAME -eq 'main')
+              }
+            }
+            if ($include) {
+              Write-Host "DeliveryTarget $_ included"
+            }
+            $include
+          })
           $deliveryTargetsJson = $deliveryTargets | ConvertTo-Json -Depth 99 -compress
           if ($deliveryTargets.Count -lt 2) { $deliveryTargetsJson = "[$($deliveryTargetsJson)]" }
           Add-Content -Path $env:GITHUB_OUTPUT -Value "DeliveryTargetsJson=$deliveryTargetsJson"
@@ -185,330 +153,53 @@ jobs:
           Write-Host "DeliveryTargetCount=$($deliveryTargets.Count)"
           Add-Content -Path $env:GITHUB_ENV -Value "DeliveryTargets=$deliveryTargetsJson"
 
-      - name: Determine Build Order
-        if: env.WorkflowDepth > 1
-        id: BuildOrder
-        run: |
-          $ErrorActionPreference = "STOP"
-          $projects = '${{ steps.ReadSettings.outputs.ProjectsJson }}' | ConvertFrom-Json
-          $buildOrder = '${{ steps.ReadSettings.outputs.BuildOrderJson }}' | ConvertFrom-Json
-          $depth = ${{ steps.ReadSettings.outputs.BuildOrderDepth }}
-          $workflowDepth = ${{ steps.ReadSettings.outputs.WorkflowDepth }}
-          if ($depth -lt $workflowDepth) {
-            Write-Host "::Error::Project Dependencies depth is $depth. Workflow is only setup for $workflowDepth. You need to Run Update AL-Go System Files to update the workflows"
-            $host.SetShouldExit(1)
-          }
-          $step = $depth
-          $depth..1 | ForEach-Object {
-            $ps = @($buildOrder."$_" | Where-Object { $projects -contains $_ })
-            if ($ps.Count -eq 1) {
-              $projectsJSon = "[$($ps | ConvertTo-Json -compress)]"
-            }
-            else {
-              $projectsJSon = $ps | ConvertTo-Json -compress
-            }
-            if ($ps.Count -gt 0) {
-              Add-Content -Path $env:GITHUB_OUTPUT -Value "Projects$($step)Json=$projectsJson"
-              Add-Content -Path $env:GITHUB_OUTPUT -Value "Projects$($step)Count=$($ps.count)"
-              Write-Host "Projects$($step)Json=$projectsJson"
-              Write-Host "Projects$($step)Count=$($ps.count)"
-              $step--
-            }
-          }
-          while ($step -ge 1) {
-              Add-Content -Path $env:GITHUB_OUTPUT -Value "Projects$($step)Json="
-              Add-Content -Path $env:GITHUB_OUTPUT -Value "Projects$($step)Count=0"
-              Write-Host "Projects$($step)Json="
-              Write-Host "Projects$($step)Count=0"
-              $step--
-          }
-
   CheckForUpdates:
     runs-on: [ windows-latest ]
     needs: [ Initialization ]
-    if: github.event_name != 'workflow_run'
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/ReadSettings@main
         with:
+          shell: powershell
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          get: TemplateUrl
+          get: templateUrl
 
       - name: Check for updates to AL-Go system files
-        uses: microsoft/AL-Go-Actions/CheckForUpdates@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/CheckForUpdates@main
         with:
+          shell: powershell
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          templateUrl: ${{ env.TemplateUrl }}
+          templateUrl: ${{ env.templateUrl }}
 
   Build:
     needs: [ Initialization ]
-    if: ${{ needs.Initialization.outputs.projectCount > 0 }}
-    runs-on: ${{ fromJson(needs.Initialization.outputs.githubRunner) }}
+    if: (!failure()) && (!cancelled()) && fromJson(needs.Initialization.outputs.buildOrderJson)[0].projectsCount > 0
     strategy:
       matrix:
-        project: ${{ fromJson(needs.Initialization.outputs.projects) }}
+        include: ${{ fromJson(needs.Initialization.outputs.buildOrderJson)[0].buildDimensions }}
       fail-fast: false
-    name: Build ${{ matrix.project }}
-    outputs:
-      AppsArtifactsName: ${{ steps.calculateArtifactNames.outputs.AppsArtifactsName }}
-      TestAppsArtifactsName: ${{ steps.calculateArtifactNames.outputs.TestAppsArtifactsName }}
-      TestResultsArtifactsName: ${{ steps.calculateArtifactNames.outputs.TestResultsArtifactsName }}
-      BcptTestResultsArtifactsName: ${{ steps.calculateArtifactNames.outputs.BcptTestResultsArtifactsName }}
-      BuildOutputArtifactsName: ${{ steps.calculateArtifactNames.outputs.BuildOutputArtifactsName }}
-    steps:
-      - name: Create Build Job Check Run
-        id: CreateCheckRun
-        if: github.event_name == 'workflow_run'
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            var jobName = context.job.concat(' ${{ matrix.project }}')
-            var jobs = await github.rest.actions.listJobsForWorkflowRun({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: context.runId
-            });
-            var job = jobs.data.jobs.filter((job) => {
-              return job.name == jobName
-            })[0];
-            var details_url = context.serverUrl.concat('/',context.repo.owner,'/',context.repo.repo,'/actions/runs/',context.runId)
-            if (job) {
-              details_url = job.html_url;
-            }
-            var response = await github.rest.checks.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: context.job.concat(' ${{ matrix.project }}'),
-              head_sha: '${{ github.event.workflow_run.head_sha }}',
-              status: 'in_progress',
-              details_url: details_url,
-              output: {
-                'title': context.job.concat(' ${{ matrix.project }}'),
-                'summary': '[Workflow Details]('.concat(details_url,')')
-              }
-            });
-            core.setOutput('checkRunId', response.data.id);
-            core.setOutput('detailsUrl', details_url);
-
-      - name: Update CI/CD Workflow Check Run
-        if: github.event_name == 'workflow_run'
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            var response = await github.rest.checks.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              check_run_id: ${{ needs.Initialization.outputs.checkRunId }},
-              status: 'in_progress'
-            });
-
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
-        with:
-          path: '${{ github.workspace }}\.dependencies'
-
-      - name: 'Download Pull Request Changes'
-        if: github.event_name == 'workflow_run'
-        uses: actions/github-script@v6
-        with:
-          script: |
-            var run_id = Number('${{ github.event.workflow_run.id }}');
-            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: run_id
-            });
-            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == 'Pull_Request_Files'
-            })[0];
-            var download = await github.rest.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
-               archive_format: 'zip'
-            });
-            var fs = require('fs');
-            fs.writeFileSync('.PullRequestChanges.zip', Buffer.from(download.data));
-
-      - name: Apply Pull Request Changes
-        if: github.event_name == 'workflow_run'
-        run: |
-          $ErrorActionPreference = "STOP"
-          $location = (Get-Location).path
-          $prfolder = '.PullRequestChanges'
-          Expand-Archive -Path ".\$prfolder.zip" -DestinationPath ".\$prfolder"
-          Remove-Item -Path ".\$prfolder.zip" -force
-          Get-ChildItem -Path $prfolder -Recurse -File | ForEach-Object {
-            $path = $_.FullName
-            $deleteFile = $path.EndsWith('.REMOVE')
-            if ($deleteFile) {
-              $path = $path.SubString(0,$path.Length-7)
-            }
-            $newPath = $path.Replace("$prfolder\","")
-            $newFolder = [System.IO.Path]::GetDirectoryName($newPath)
-            $extension = [System.IO.Path]::GetExtension($path)
-            $filename = [System.IO.Path]::GetFileName($path)
-            if ('${{ github.event.workflow_run.head_repository.full_name }}' -ne $ENV:GITHUB_REPOSITORY) {
-              if ($extension -eq '.ps1' -or $extension -eq '.yaml' -or $extension -eq '.yml' -or $filename -eq "CODEOWNERS") {
-                throw "Pull Request containing changes to scripts, workflows or CODEOWNERS are not allowed from forks."
-              }
-            }
-            if ($deleteFile) {
-              if (Test-Path $newPath) {
-                Write-Host "Removing $newPath"
-                Remove-Item $newPath -Force
-              }
-              else {
-                Write-Host "$newPath was already deleted"
-              }
-            }
-            else {
-              if (-not (Test-Path $newFolder)) {
-                New-Item $newFolder -ItemType Directory | Out-Null
-              }
-              Write-Host "Copying $path to $newFolder"
-              Copy-Item $path -Destination $newFolder -Force
-            }
-          }
-
-      - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v2.1
-        with:
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          project: ${{ matrix.project }}
-
-      - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v2.1
-        env:
-          secrets: ${{ toJson(secrets) }}
-        with:
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          settingsJson: ${{ env.Settings }}
-          secrets: 'licenseFileUrl,insiderSasToken,CodeSignCertificateUrl,CodeSignCertificatePassword,KeyVaultCertificateUrl,KeyVaultCertificatePassword,KeyVaultClientId,StorageContext,GitHubPackagesContext'
-
-      - name: Run pipeline
-        id: RunPipeline
-        uses: microsoft/AL-Go-Actions/RunPipeline@v2.1
-        with:
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          Project: ${{ matrix.project }}
-          ProjectDependenciesJson: ${{ needs.Initialization.outputs.projectDependenciesJson }}
-          settingsJson: ${{ env.Settings }}
-          SecretsJson: ${{ env.RepoSecrets }}
-
-      - name: Calculate Artifact names
-        id: calculateArtifactNames
-        if: success() || failure()
-        run: |
-          $ErrorActionPreference = "STOP"
-          $settings = '${{ env.Settings }}' | ConvertFrom-Json
-          $project = '${{ matrix.project }}'
-          if ($project -eq ".") { $project = $settings.RepoName }
-          'Apps','Dependencies','TestApps','TestResults','BcptTestResults','BuildOutput' | ForEach-Object {
-            $name = "$($_)ArtifactsName"
-            $value = "$($project.Replace('\','_'))-$("$ENV:GITHUB_REF_NAME".Replace('/','_'))-$_-$($settings.repoVersion).$($settings.appBuild).$($settings.appRevision)"
-            Add-Content -Path $env:GITHUB_OUTPUT -Value "$name=$value"
-            Add-Content -Path $env:GITHUB_ENV -Value "$name=$value"
-          }
-
-      - name: Publish artifacts - apps
-        uses: actions/upload-artifact@v3
-        if: (github.event_name != 'workflow_run') && (github.ref_name == 'main' || startswith(github.ref_name, 'release/'))
-        with:
-          name: ${{ env.appsArtifactsName }}
-          path: '${{ matrix.project }}/.buildartifacts/Apps/'
-          if-no-files-found: ignore
-
-      - name: Publish artifacts - dependencies
-        uses: actions/upload-artifact@v3
-        if: (github.event_name != 'workflow_run') && (github.ref_name == 'main' || startswith(github.ref_name, 'release/'))
-        with:
-          name: ${{ env.dependenciesArtifactsName }}
-          path: '${{ matrix.project }}/.buildartifacts/Dependencies/'
-          if-no-files-found: ignore
-
-      - name: Publish artifacts - test apps
-        uses: actions/upload-artifact@v3
-        if: (github.event_name != 'workflow_run') && (github.ref_name == 'main' || startswith(github.ref_name, 'release/'))
-        with:
-          name: ${{ env.testAppsArtifactsName }}
-          path: '${{ matrix.project }}/.buildartifacts/TestApps/'
-          if-no-files-found: ignore
-
-      - name: Publish artifacts - build output
-        uses: actions/upload-artifact@v3
-        if: (success() || failure()) && (hashFiles(format('{0}/BuildOutput.txt',matrix.project)) != '')
-        with:
-          name: ${{ env.buildOutputArtifactsName }}
-          path: '${{ matrix.project }}/BuildOutput.txt'
-          if-no-files-found: ignore
-
-      - name: Publish artifacts - test results
-        uses: actions/upload-artifact@v3
-        if: (success() || failure()) && (hashFiles(format('{0}/TestResults.xml',matrix.project)) != '')
-        with:
-          name: ${{ env.testResultsArtifactsName }}
-          path: '${{ matrix.project }}/TestResults.xml'
-          if-no-files-found: ignore
-
-      - name: Publish artifacts - bcpt test results
-        uses: actions/upload-artifact@v3
-        if: (success() || failure()) && (hashFiles(format('{0}/bcptTestResults.json',matrix.project)) != '')
-        with:
-          name: ${{ env.bcptTestResultsArtifactsName }}
-          path: '${{ matrix.project }}/bcptTestResults.json'
-          if-no-files-found: ignore
-
-      - name: Analyze Test Results
-        id: analyzeTestResults
-        if: success() || failure()
-        uses: microsoft/AL-Go-Actions/AnalyzeTests@v2.1
-        with:
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          Project: ${{ matrix.project }}
-
-      - name: Update Build Job Check Run
-        if: always() && github.event_name == 'workflow_run'
-        uses: actions/github-script@v6
-        env:
-          TestResultMD: ${{ steps.analyzeTestResults.outputs.TestResultMD }}
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            var details_url = '${{ steps.CreateCheckRun.outputs.detailsUrl }}'
-            var testResultMD = process.env.TestResultMD
-            var response = await github.rest.checks.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              check_run_id: ${{ steps.CreateCheckRun.outputs.checkRunId }},
-              conclusion: '${{ steps.RunPipeline.conclusion }}',
-              output: {
-                title: context.job.concat(' ${{ matrix.project }}'),
-                summary: testResultMD.replaceAll('\\n','\n'),
-                text: '[Workflow details]('.concat(details_url,')')
-              }
-            });
-
-      - name: Cleanup
-        if: always()
-        uses: microsoft/AL-Go-Actions/PipelineCleanup@v2.1
-        with:
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          Project: ${{ matrix.project }}
+    name: Build ${{ matrix.project }} - ${{ matrix.buildMode }}
+    uses: ./.github/workflows/_BuildALGoProject.yaml
+    secrets: inherit
+    with:
+      shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
+      runsOn: ${{ needs.Initialization.outputs.githubRunner }}
+      parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+      project: ${{ matrix.project }}
+      buildMode: ${{ matrix.buildMode }}
+      projectDependenciesJson: ${{ needs.Initialization.outputs.projectDependenciesJson }}
+      secrets: 'licenseFileUrl,insiderSasToken,codeSignCertificateUrl,codeSignCertificatePassword,keyVaultCertificateUrl,keyVaultCertificatePassword,keyVaultClientId,storageContext,gitHubPackagesContext'
+      publishThisBuildArtifacts: ${{ needs.Initialization.outputs.workflowDepth > 1 }}
+      publishArtifacts: ${{ github.ref_name == 'main' || startswith(github.ref_name, 'release/') || needs.Initialization.outputs.deliveryTargetCount > 0 || needs.Initialization.outputs.environmentCount > 0 }}
+      signArtifacts: true
+      useArtifactCache: true
 
   Deploy:
     needs: [ Initialization, Build ]
-    if: always() && needs.Build.result == 'Success' && github.event_name != 'workflow_run' && github.ref_name == 'main' && needs.Initialization.outputs.environmentCount > 0
+    if: always() && needs.Build.result == 'Success' && needs.Initialization.outputs.environmentCount > 0
     strategy: ${{ fromJson(needs.Initialization.outputs.environments) }}
     runs-on: ${{ fromJson(matrix.os) }}
     name: Deploy to ${{ matrix.environment }}
@@ -521,37 +212,49 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v3
         with:
-          path: '${{ github.workspace }}\.artifacts'
+          path: '.artifacts'
 
       - name: EnvName
         id: envName
         run: |
           $ErrorActionPreference = "STOP"
+          Set-StrictMode -version 2.0
           $envName = '${{ matrix.environment }}'.split(' ')[0]
           Add-Content -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/ReadSettings@main
+        with:
+          shell: powershell
 
       - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/ReadSecrets@main
         env:
           secrets: ${{ toJson(secrets) }}
         with:
+          shell: powershell
           settingsJson: ${{ env.Settings }}
-          secrets: '${{ steps.envName.outputs.envName }}-AuthContext,${{ steps.envName.outputs.envName }}_AuthContext,AuthContext,${{ steps.envName.outputs.envName }}-EnvironmentName,${{ steps.envName.outputs.envName }}_EnvironmentName,EnvironmentName,Projects'
+          secrets: '${{ steps.envName.outputs.envName }}-AuthContext,${{ steps.envName.outputs.envName }}_AuthContext,AuthContext,${{ steps.envName.outputs.envName }}-EnvironmentName,${{ steps.envName.outputs.envName }}_EnvironmentName,EnvironmentName,projects'
 
       - name: AuthContext
         id: authContext
         run: |
           $ErrorActionPreference = "STOP"
+          Set-StrictMode -version 2.0
           $envName = '${{ steps.envName.outputs.envName }}'
+          $deployToSettingStr = [System.Environment]::GetEnvironmentVariable("DeployTo$envName")
+          if ($deployToSettingStr) {
+            $deployToSetting = $deployToSettingStr | ConvertFrom-Json
+          }
+          else {
+            $deployToSetting = [PSCustomObject]@{}
+          }
           $authContext = $null
           "$($envName)-AuthContext", "$($envName)_AuthContext", "AuthContext" | ForEach-Object {
             if (!($authContext)) {
               $authContext = [System.Environment]::GetEnvironmentVariable($_)
               if ($authContext) {
-                Write-Host "Using $_ secret"
+                Write-Host "Using $_ secret as AuthContext"
               }
             }            
           }
@@ -559,28 +262,39 @@ jobs:
             Write-Host "::Error::No AuthContext provided"
             exit 1
           }
-          $environmentName = $null
-          "$($envName)-EnvironmentName", "$($envName)_EnvironmentName", "EnvironmentName" | ForEach-Object {
-            if (!($EnvironmentName)) {
-              $EnvironmentName = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String([System.Environment]::GetEnvironmentVariable($_)))
-              if ($EnvironmentName) {
-                Write-Host "Using $_ secret"
-              }
-            }            
+          if (("$deployToSetting" -ne "") -and $deployToSetting.PSObject.Properties.name -eq "EnvironmentName") {
+            $environmentName = $deployToSetting.EnvironmentName
+          }
+          else {
+            $environmentName = $null
+            "$($envName)-EnvironmentName", "$($envName)_EnvironmentName", "EnvironmentName" | ForEach-Object {
+              if (!($EnvironmentName)) {
+                $EnvironmentName = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String([System.Environment]::GetEnvironmentVariable($_)))
+                if ($EnvironmentName) {
+                  Write-Host "Using $_ secret as EnvironmentName"
+                  Write-Host "Please consider using the DeployTo$_ setting instead, where you can specify EnvironmentName, projects and branches"
+                }
+              }            
+            }
           }
           if (!($environmentName)) {
             $environmentName = '${{ steps.envName.outputs.envName }}'
           }
           $environmentName = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes(($environmentName + '${{ matrix.environment }}'.SubString($envName.Length)).ToUpperInvariant()))
 
-          $projects = [System.Environment]::GetEnvironmentVariable("$($envName)-Projects")
-          if (-not $projects) {
-            $projects = [System.Environment]::GetEnvironmentVariable("$($envName)_Projects")
+          if (("$deployToSetting" -ne "") -and $deployToSetting.PSObject.Properties.name -eq "projects") {
+            $projects = $deployToSetting.projects
+          }
+          else {
+            $projects = [System.Environment]::GetEnvironmentVariable("$($envName)-projects")
             if (-not $projects) {
-              $projects = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String([System.Environment]::GetEnvironmentVariable('projects')))
+              $projects = [System.Environment]::GetEnvironmentVariable("$($envName)_Projects")
+              if (-not $projects) {
+                $projects = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String([System.Environment]::GetEnvironmentVariable('projects')))
+              }
             }
           }
-          if ($projects -eq '') {
+          if ($projects -eq '' -or $projects -eq '*') {
             $projects = '*'
           }
           else {
@@ -591,23 +305,25 @@ jobs:
           Add-Content -Path $env:GITHUB_OUTPUT -Value "authContext=$authContext"
           Write-Host "authContext=$authContext"
           Add-Content -Path $env:GITHUB_OUTPUT -Value "environmentName=$environmentName"
-          Write-Host "environmentName=$environmentName"
+          Write-Host "environmentName=$([System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($environmentName)))"
+          Write-Host "environmentName (as Base64)=$environmentName"
           Add-Content -Path $env:GITHUB_OUTPUT -Value "projects=$projects"
           Write-Host "projects=$projects"
 
       - name: Deploy
-        uses: microsoft/AL-Go-Actions/Deploy@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/Deploy@main
         env:
-          authContext: ${{ steps.authContext.outputs.authContext }}
+          AuthContext: ${{ steps.authContext.outputs.authContext }}
         with:
+          shell: powershell
           type: 'CD'
           projects: ${{ steps.authContext.outputs.projects }}
           environmentName: ${{ steps.authContext.outputs.environmentName }}
-          artifacts: '${{ github.workspace }}\.artifacts'
+          artifacts: '.artifacts'
 
   Deliver:
     needs: [ Initialization, Build ]
-    if: always() && needs.Build.result == 'Success' && github.event_name != 'workflow_run' && github.ref_name == 'main' && needs.Initialization.outputs.deliveryTargetCount > 0
+    if: always() && needs.Build.result == 'Success' && needs.Initialization.outputs.deliveryTargetCount > 0
     strategy:
       matrix:
         deliveryTarget: ${{ fromJson(needs.Initialization.outputs.deliveryTargets) }}
@@ -621,16 +337,19 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v3
         with:
-          path: '${{ github.workspace }}\.artifacts'
+          path: '.artifacts'
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/ReadSettings@main
+        with:
+          shell: powershell
 
       - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/ReadSecrets@main
         env:
           secrets: ${{ toJson(secrets) }}
         with:
+          shell: powershell
           settingsJson: ${{ env.Settings }}
           secrets: '${{ matrix.deliveryTarget }}Context'
 
@@ -638,40 +357,25 @@ jobs:
         id: deliveryContext
         run: |
           $ErrorActionPreference = "STOP"
+          Set-StrictMode -version 2.0
           $contextName = '${{ matrix.deliveryTarget }}Context'
           $deliveryContext = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String([System.Environment]::GetEnvironmentVariable($contextName)))
           Add-Content -Path $env:GITHUB_OUTPUT -Value "deliveryContext=$deliveryContext"
           Write-Host "deliveryContext=$deliveryContext"
 
       - name: Deliver
-        uses: microsoft/AL-Go-Actions/Deliver@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/Deliver@main
         env:
           deliveryContext: ${{ steps.deliveryContext.outputs.deliveryContext }}
         with:
+          shell: powershell
           type: 'CD'
           projects: ${{ needs.Initialization.outputs.projects }}
           deliveryTarget: ${{ matrix.deliveryTarget }}
-          artifacts: '${{ github.workspace }}\.artifacts'
-
-  UpdatePRcheck:
-    if: always() && github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
-    runs-on: [ windows-latest ]
-    needs: [ Initialization, Build ]
-    steps:
-      - name: Update CI/CD Workflow Check Run
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            var response = await github.rest.checks.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              check_run_id: ${{ needs.Initialization.outputs.checkRunId }},
-              conclusion: '${{ needs.Build.result }}'
-            });
+          artifacts: '.artifacts'
 
   PostProcess:
-    if: (!cancelled()) && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
+    if: (!cancelled())
     runs-on: [ windows-latest ]
     needs: [ Initialization, Build, Deploy, Deliver ]
     steps:
@@ -680,7 +384,8 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/WorkflowPostProcess@main
         with:
+          shell: powershell
           eventId: "DO0091"
           telemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}

--- a/.github/workflows/CreateApp.yaml
+++ b/.github/workflows/CreateApp.yaml
@@ -1,4 +1,6 @@
-name: 'Create a new app'
+﻿name: 'Create a new app'
+
+run-name: "Create a new app in [${{ github.ref_name }}]"
 
 on:
   workflow_dispatch:
@@ -31,7 +33,11 @@ permissions:
 
 defaults:
   run:
-    shell: PowerShell
+    shell: powershell
+
+env:
+  ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
+  ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
 
 jobs:
   CreateApp:
@@ -42,19 +48,22 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/WorkflowInitialize@main
         with:
+          shell: powershell
           eventId: "DO0092"
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/ReadSettings@main
         with:
+          shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           get: type
 
       - name: Creating a new app
-        uses: microsoft/AL-Go-Actions/CreateApp@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/CreateApp@main
         with:
+          shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           project: ${{ github.event.inputs.project }}
           type: ${{ env.type }}
@@ -66,7 +75,8 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/WorkflowPostProcess@main
         with:
+          shell: powershell
           eventId: "DO0092"
           telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}

--- a/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -1,4 +1,6 @@
-name: ' Create Online Dev. Environment'
+﻿name: ' Create Online Dev. Environment'
+
+run-name: "Create Online Dev. Environment for [${{ github.ref_name }}]"
 
 on:
   workflow_dispatch:
@@ -21,67 +23,115 @@ permissions:
 
 defaults:
   run:
-    shell: PowerShell
+    shell: powershell
+
+env:
+  ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
+  ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
 
 jobs:
-  CreateOnlineDevelopmentEnvironment:
+  Initialize:
     runs-on: [ windows-latest ]
+    outputs:
+      deviceCode: ${{ steps.authenticate.outputs.deviceCode }}
+      telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/WorkflowInitialize@main
         with:
+          shell: powershell
           eventId: "DO0093"
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/ReadSettings@main
         with:
+          shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
 
       - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/ReadSecrets@main
         env:
           secrets: ${{ toJson(secrets) }}
         with:
+          shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           settingsJson: ${{ env.Settings }}
           secrets: 'adminCenterApiCredentials'
 
       - name: Check AdminCenterApiCredentials / Initiate Device Login (open to see code)
+        id: authenticate
         run: |
+          $ErrorActionPreference = "STOP"
+          Set-StrictMode -version 2.0
           $adminCenterApiCredentials = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($env:adminCenterApiCredentials))
           if ($adminCenterApiCredentials) {
-            Write-Host "AdminCenterApiCredentials provided!"
+            Write-Host "AdminCenterApiCredentials provided in secret $($ENV:adminCenterApiCredentialsSecretName)!"
+            Set-Content -Path $ENV:GITHUB_STEP_SUMMARY -value "Admin Center Api Credentials was provided in a secret called $($ENV:adminCenterApiCredentialsSecretName). Using this information for authentication."
           }
           else {
             Write-Host "AdminCenterApiCredentials not provided, initiating Device Code flow"
             $ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
             $webClient = New-Object System.Net.WebClient
-            $webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v2.1/AL-Go-Helper.ps1', $ALGoHelperPath)
+            $webClient.DownloadFile('https://raw.githubusercontent.com/businesscentralapps/tmp54nzkP-Actions/main/AL-Go-Helper.ps1', $ALGoHelperPath)
             . $ALGoHelperPath
             $BcContainerHelperPath = DownloadAndImportBcContainerHelper -baseFolder $ENV:GITHUB_WORKSPACE
             $authContext = New-BcAuthContext -includeDeviceLogin -deviceLoginTimeout ([TimeSpan]::FromSeconds(0))
-            MaskValueInLog -value $authContext.deviceCode
-            $adminCenterApiCredentials = "{""deviceCode"":""$($authContext.deviceCode)""}"
-            Add-Content -Path $env:GITHUB_ENV -Value "adminCenterApiCredentials=$([Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($adminCenterApiCredentials)))"
             CleanupAfterBcContainerHelper -bcContainerHelperPath $bcContainerHelperPath
+            Set-Content -Path $ENV:GITHUB_STEP_SUMMARY -value "AL-Go needs access to the Business Central Admin Center Api and could not locate a secret called $($ENV:adminCenterApiCredentialsSecretName) (https://aka.ms/ALGoSettings#AdminCenterApiCredentialsSecretName)`n`n$($authContext.message)"
+            Add-Content -Path $env:GITHUB_OUTPUT -Value "deviceCode=$($authContext.deviceCode)"
+          }
+
+  CreateDevelopmentEnvironment:
+    runs-on: [ windows-latest ]
+    name: Create Development Environment
+    needs: [ Initialize ]
+    env:
+      deviceCode: ${{ needs.Initialize.outputs.deviceCode }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Read settings
+        uses: businesscentralapps/tmp54nzkP-Actions/ReadSettings@main
+        with:
+          shell: powershell
+          parentTelemetryScopeJson: ${{ needs.Initialize.outputs.telemetryScopeJson }}
+
+      - name: Read secrets
+        uses: businesscentralapps/tmp54nzkP-Actions/ReadSecrets@main
+        env:
+          secrets: ${{ toJson(secrets) }}
+        with:
+          shell: powershell
+          parentTelemetryScopeJson: ${{ needs.Initialize.outputs.telemetryScopeJson }}
+          settingsJson: ${{ env.Settings }}
+          secrets: 'adminCenterApiCredentials'
+
+      - name: Set AdminCenterApiCredentials
+        run: |
+          if ($env:deviceCode) {
+            $adminCenterApiCredentials = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes("{""deviceCode"":""$($env:deviceCode)""}"))
+            Add-Content -path $env:GITHUB_ENV -value "adminCenterApiCredentials=$adminCenterApiCredentials"
           }
 
       - name: Create Development Environment
-        uses: microsoft/AL-Go-Actions/CreateDevelopmentEnvironment@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/CreateDevelopmentEnvironment@main
         with:
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          shell: powershell
+          parentTelemetryScopeJson: ${{ needs.Initialize.outputs.telemetryScopeJson }}
           environmentName: ${{ github.event.inputs.environmentName }}
           reUseExistingEnvironment: ${{ github.event.inputs.reUseExistingEnvironment }}
           directCommit: ${{ github.event.inputs.directCommit }}
-          adminCenterApiCredentials: ${{ env.adminCenterApiCredentials }} 
+          adminCenterApiCredentials: ${{ env.adminCenterApiCredentials }}
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/WorkflowPostProcess@main
         with:
+          shell: powershell
           eventId: "DO0093"
-          telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          telemetryScopeJson: ${{ needs.Initialize.outputs.telemetryScopeJson }}

--- a/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/.github/workflows/CreatePerformanceTestApp.yaml
@@ -1,4 +1,6 @@
-name: 'Create a new performance test app'
+﻿name: 'Create a new performance test app'
+
+run-name: "Create a new performance test app in [${{ github.ref_name }}]"
 
 on:
   workflow_dispatch:
@@ -37,7 +39,11 @@ permissions:
 
 defaults:
   run:
-    shell: PowerShell
+    shell: powershell
+
+env:
+  ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
+  ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
 
 jobs:
   CreatePerformanceTestApp:
@@ -48,13 +54,15 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/WorkflowInitialize@main
         with:
+          shell: powershell
           eventId: "DO0102"
 
       - name: Creating a new test app
-        uses: microsoft/AL-Go-Actions/CreateApp@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/CreateApp@main
         with:
+          shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           project: ${{ github.event.inputs.project }}
           type: 'Performance Test App'
@@ -67,7 +75,8 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/WorkflowPostProcess@main
         with:
+          shell: powershell
           eventId: "DO0102"
           telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}

--- a/.github/workflows/CreateRelease.yaml
+++ b/.github/workflows/CreateRelease.yaml
@@ -1,4 +1,4 @@
-name: ' Create release'
+﻿name: ' Create release'
 
 on:
   workflow_dispatch:
@@ -45,75 +45,114 @@ concurrency: release
 
 defaults:
   run:
-    shell: PowerShell
+    shell: powershell
+
+env:
+  ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
+  ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
 
 jobs:
-  Initialization:
+  CreateRelease:
     runs-on: [ windows-latest ]
     outputs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+      artifacts: ${{ steps.analyzeartifacts.outputs.artifacts }}
+      releaseId: ${{ steps.createrelease.outputs.releaseId }}
+      commitish: ${{ steps.analyzeartifacts.outputs.commitish }}
+      releaseBranch: ${{ steps.createreleasenotes.outputs.releaseBranch }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/WorkflowInitialize@main
         with:
+          shell: powershell
           eventId: "DO0094"
-
-  CreateRelease:
-    runs-on: [ windows-latest ]
-    needs: [ Initialization ]
-    outputs:
-      artifacts: ${{ steps.analyzeartifacts.outputs.artifacts }}
-      upload_url: ${{ steps.createrelease.outputs.upload_url }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/ReadSettings@main
         with:
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          get: TemplateUrl,RepoName
-          getProjects: 'Y'
+          shell: powershell
+          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          get: templateUrl,repoName
+
+      - name: Determine Projects
+        id: determineProjects
+        uses: businesscentralapps/tmp54nzkP-Actions/DetermineProjectsToBuild@main
+        with:
+          shell: powershell
 
       - name: Check for updates to AL-Go system files
-        uses: microsoft/AL-Go-Actions/CheckForUpdates@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/CheckForUpdates@main
         with:
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          templateUrl: ${{ env.TemplateUrl }}
+          shell: powershell
+          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          templateUrl: ${{ env.templateUrl }}
 
       - name: Analyze Artifacts
         id: analyzeartifacts
         run: |
           $ErrorActionPreference = "STOP"
-          $projects = '${{ steps.ReadSettings.outputs.ProjectsJson }}' | ConvertFrom-Json
-          $projects | out-host
+          Set-StrictMode -version 2.0
+          $projects = '${{ steps.determineProjects.outputs.ProjectsJson }}' | ConvertFrom-Json
+          Write-Host "projects:"
+          $projects | ForEach-Object { Write-Host "- $_" }
           $include = @()
+          $sha = ''
+          $allArtifacts = @()
+          $page = 1
+          $headers = @{ 
+            "Authorization" = "token ${{ github.token }}"
+            "Accept"        = "application/json"
+          }
+          do {
+            $repoArtifacts = Invoke-WebRequest -UseBasicParsing -Headers $headers -Uri "$($ENV:GITHUB_API_URL)/repos/$($ENV:GITHUB_REPOSITORY)/actions/artifacts?per_page=100&page=$page" | ConvertFrom-Json
+            $allArtifacts += $repoArtifacts.Artifacts | Where-Object { !$_.expired }
+            $page++
+          }
+          while ($repoArtifacts.Artifacts.Count -gt 0)
+          Write-Host "Repo Artifacts count: $($repoArtifacts.total_count)"
+          Write-Host "Downloaded Artifacts count: $($allArtifacts.Count)"
           $projects | ForEach-Object {
             $thisProject = $_
             if ($thisProject -and ($thisProject -ne '.')) {
-              $project = $thisProject.Replace('\','_')
+              $project = $thisProject.Replace('\','_').Replace('/','_')
             }
             else {
-              $project = $env:RepoName
+              $project = $env:repoName
             }
+            $refname = "$ENV:GITHUB_REF_NAME".Replace('/','_')
             Write-Host "Analyzing artifacts for project $project"
             $appVersion = '${{ github.event.inputs.appVersion }}'
-            $headers = @{ 
-                "Authorization" = "token ${{ github.token }}"
-                "Accept"        = "application/json"
-            }
-            $allArtifacts = Invoke-WebRequest -UseBasicParsing -Headers $headers -Uri "$($ENV:GITHUB_API_URL)/repos/$($ENV:GITHUB_REPOSITORY)/actions/artifacts" | ConvertFrom-Json
-            $artifactsVersion = $appVersion
             if ($appVersion -eq "latest") {
-              $artifact = $allArtifacts.artifacts | Where-Object { $_.name -like "$project-*-Apps-*" } | Select-Object -First 1
-              $artifactsVersion = $artifact.name.SubString($artifact.name.IndexOf('-Apps-')+6)
+              Write-Host "Grab latest"
+              $artifact = $allArtifacts | Where-Object { $_.name -like "$project-$refname-Apps-*" } | Select-Object -First 1
             }
-            $allArtifacts.artifacts | Where-Object { $_.name -like "$project-*-Apps-$($artifactsVersion)" -or $_.name -like "$project-*-TestApps-$($artifactsVersion)" -or $_.name -like "$project-*-Dependencies-$($artifactsVersion)" } | ForEach-Object {
+            else {
+              Write-Host "Search for $project-$refname-Apps-$appVersion"
+              $artifact = $allArtifacts | Where-Object { $_.name -eq "$project-$refname-Apps-$appVersion" } | Select-Object -First 1
+            }
+            if ($artifact) {
+              $artifactsVersion = $artifact.name.SubString($artifact.name.LastIndexOf('-Apps-')+6)
+            }
+            else {
+              Write-Host "::Error::No artifacts found for this project"
+              exit 1
+            }
+            if ($sha) {
+              if ($artifact.workflow_run.head_sha -ne $sha) {
+                Write-Host "::Error::The build selected for release doesn't contain all projects. Please rebuild all projects by manually running the CI/CD workflow and recreate the release."
+                throw "The build selected for release doesn't contain all projects. Please rebuild all projects by manually running the CI/CD workflow and recreate the release."
+              }
+            }
+            else {
+              $sha = $artifact.workflow_run.head_sha
+            }
+
+            $allArtifacts | Where-Object { ($_.name -like "$project-$refname-Apps-$($artifactsVersion)" -or $_.name -like "$project-$refname-TestApps-$($artifactsVersion)" -or $_.name -like "$project-$refname-Dependencies-$($artifactsVersion)") } | ForEach-Object {
               $atype = $_.name.SubString(0,$_.name.Length-$artifactsVersion.Length-1)
               $atype = $atype.SubString($atype.LastIndexOf('-')+1)
               $include += $( [ordered]@{ "name" = $_.name; "url" = $_.archive_download_url; "atype" = $atype; "project" = $thisproject } )
@@ -127,28 +166,44 @@ jobs:
           $artifactsJson = $artifacts | ConvertTo-Json -compress
           Add-Content -Path $env:GITHUB_OUTPUT -Value "artifacts=$artifactsJson"
           Write-Host "artifacts=$artifactsJson"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "commitish=$sha"
+          Write-Host "commitish=$sha"
 
       - name: Prepare release notes
         id: createreleasenotes
-        uses: microsoft/AL-Go-Actions/CreateReleaseNotes@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/CreateReleaseNotes@main
         with:
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+          shell: powershell
+          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           tag_name: ${{ github.event.inputs.tag }}
 
       - name: Create release
-        uses: actions/create-release@v1
+        uses: actions/github-script@v6
         id: createrelease
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          bodyMD: ${{ steps.createreleasenotes.outputs.releaseNotes }}
         with:
-          draft: ${{ github.event.inputs.draft=='Y' }}
-          prerelease: ${{ github.event.inputs.prerelease=='Y' }}
-          release_name: ${{ github.event.inputs.name }}
-          tag_name: ${{ github.event.inputs.tag }}
-          body: ${{ steps.createreleasenotes.outputs.releaseNotes }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            var bodyMD = process.env.bodyMD
+            const createReleaseResponse = await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: '${{ github.event.inputs.tag }}',
+              name: '${{ github.event.inputs.name }}',
+              body: bodyMD.replaceAll('\\n','\n').replaceAll('%0A','\n').replaceAll('%0D','\n').replaceAll('%25','%'),
+              draft: ${{ github.event.inputs.draft=='Y' }},
+              prerelease: ${{ github.event.inputs.prerelease=='Y' }},
+              make_latest: 'legacy',
+              target_commitish: '${{ steps.analyzeartifacts.outputs.commitish }}'
+            });
+            const {
+              data: { id: releaseId, html_url: htmlUrl, upload_url: uploadUrl }
+            } = createReleaseResponse;
+            core.setOutput('releaseId', releaseId);
 
   UploadArtifacts:
-    runs-on: [ windows-latest ] 
+    runs-on: [ windows-latest ]
     needs: [ CreateRelease ]
     strategy:
       matrix: ${{ fromJson(needs.CreateRelease.outputs.artifacts) }}
@@ -158,81 +213,95 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/ReadSettings@main
         with:
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+          shell: powershell
+          parentTelemetryScopeJson: ${{ needs.CreateRelease.outputs.telemetryScopeJson }}
 
       - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/ReadSecrets@main
         env:
           secrets: ${{ toJson(secrets) }}
         with:
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+          shell: powershell
+          parentTelemetryScopeJson: ${{ needs.CreateRelease.outputs.telemetryScopeJson }}
           settingsJson: ${{ env.Settings }}
-          secrets: 'NuGetContext,StorageContext'
+          secrets: 'nuGetContext,storageContext'
 
       - name: Download artifact
         run: |
           $ErrorActionPreference = "STOP"
+          Set-StrictMode -version 2.0
           Write-Host "Downloading artifact ${{ matrix.name}}"
           $headers = @{ 
               "Authorization" = "token ${{ github.token }}"
               "Accept"        = "application/vnd.github.v3+json"
           }
           Invoke-WebRequest -UseBasicParsing -Headers $headers -Uri '${{ matrix.url }}' -OutFile '${{ matrix.name }}.zip'
-          
-      - name: Upload release artifacts
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          upload_url: ${{ needs.createrelease.outputs.upload_url }}
-          asset_path: '${{ matrix.name }}.zip'
-          asset_name: '${{ matrix.name }}.zip'
-          asset_content_type: application/zip
 
-      - name: NuGetContext
+      - name: Upload release artifacts
+        uses: actions/github-script@v6
+        env:
+          releaseId: ${{ needs.createrelease.outputs.releaseId }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const releaseId = process.env.releaseId
+            const assetPath = '${{ matrix.name }}.zip'
+            const assetName = '${{ matrix.name }}.zip'
+            const fs = require('fs');
+            const uploadAssetResponse = await github.rest.repos.uploadReleaseAsset({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: releaseId,
+              name: assetName,
+              data: fs.readFileSync(assetPath)
+            });
+
+      - name: nuGetContext
         id: nuGetContext
-        if: ${{ env.NuGetContext }}
+        if: ${{ env.nuGetContext }}
         run: |
           $ErrorActionPreference = "STOP"
+          Set-StrictMode -version 2.0
           $nuGetContext = ''
           if ('${{ matrix.atype }}' -eq 'Apps') {
-            $nuGetContext = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String([System.Environment]::GetEnvironmentVariable('NuGetContext')))
+            $nuGetContext = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String([System.Environment]::GetEnvironmentVariable('nuGetContext')))
           }
           Add-Content -Path $env:GITHUB_OUTPUT -Value "nuGetContext=$nuGetContext"
-          Write-Host "nuGetContext=$nuGetContext"
 
       - name: Deliver to NuGet
-        uses: microsoft/AL-Go-Actions/Deliver@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/Deliver@main
         if: ${{ steps.nuGetContext.outputs.nuGetContext }}
         env:
           deliveryContext: ${{ steps.nuGetContext.outputs.nuGetContext }}
         with:
+          shell: powershell
           type: 'Release'
           projects: ${{ matrix.project }}
           deliveryTarget: 'NuGet'
           artifacts: ${{ github.event.inputs.appVersion }}
           atypes: 'Apps,TestApps'
 
-      - name: StorageContext
+      - name: storageContext
         id: storageContext
-        if: ${{ env.StorageContext }}
+        if: ${{ env.storageContext }}
         run: |
           $ErrorActionPreference = "STOP"
+          Set-StrictMode -version 2.0
           $storageContext = ''
           if ('${{ matrix.atype }}' -eq 'Apps') {
-            $storageContext = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String([System.Environment]::GetEnvironmentVariable('StorageContext')))
+            $storageContext = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String([System.Environment]::GetEnvironmentVariable('storageContext')))
           }
-          Write-Host "Add-Content -Path $env:GITHUB_OUTPUT -Value "storageContext=$storageContext"
-          Write-Host "storageContext=$storageContext"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "storageContext=$storageContext"
 
       - name: Deliver to Storage
-        uses: microsoft/AL-Go-Actions/Deliver@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/Deliver@main
         if: ${{ steps.storageContext.outputs.storageContext }}
         env:
           deliveryContext: ${{ steps.storageContext.outputs.storageContext }}
         with:
+          shell: powershell
           type: 'Release'
           projects: ${{ matrix.project }}
           deliveryTarget: 'Storage'
@@ -242,43 +311,48 @@ jobs:
   CreateReleaseBranch:
     if: ${{ github.event.inputs.createReleaseBranch=='Y' }}
     runs-on: [ windows-latest ]
-    needs: [ Initialization, CreateRelease, UploadArtifacts ]
+    needs: [ CreateRelease, UploadArtifacts ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: '${{ needs.createRelease.outputs.commitish }}'
 
       - name: Create Release Branch
         run: |
           $ErrorActionPreference = "STOP"
-          git checkout -b release/${{ github.event.inputs.tag }}
+          Set-StrictMode -version 2.0
+          git checkout -b ${{ needs.CreateRelease.outputs.releaseBranch }}
           git config user.name ${{ github.actor}}
           git config user.email ${{ github.actor}}@users.noreply.github.com
-          git commit --allow-empty -m "Release branch ${{ github.event.inputs.tag }}"
-          git push origin release/${{ github.event.inputs.tag }}
+          git commit --allow-empty -m "Release branch ${{ needs.CreateRelease.outputs.releaseBranch }}"
+          git push origin ${{ needs.CreateRelease.outputs.releaseBranch }}
 
   UpdateVersionNumber:
     if: ${{ github.event.inputs.updateVersionNumber!='' }}
     runs-on: [ windows-latest ]
-    needs: [ Initialization, CreateRelease, UploadArtifacts ]
+    needs: [ CreateRelease, UploadArtifacts ]
     steps:
       - name: Update Version Number
-        uses: microsoft/AL-Go-Actions/IncrementVersionNumber@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/IncrementVersionNumber@main
         with:
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+          shell: powershell
+          parentTelemetryScopeJson: ${{ needs.CreateRelease.outputs.telemetryScopeJson }}
           versionNumber: ${{ github.event.inputs.updateVersionNumber }}
           directCommit: ${{ github.event.inputs.directCommit }}
 
   PostProcess:
     if: always()
     runs-on: [ windows-latest ]
-    needs: [ Initialization, CreateRelease, UploadArtifacts, CreateReleaseBranch, UpdateVersionNumber ]
+    needs: [ CreateRelease, UploadArtifacts, CreateReleaseBranch, UpdateVersionNumber ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/WorkflowPostProcess@main
         with:
+          shell: powershell
           eventId: "DO0094"
-          telemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+          telemetryScopeJson: ${{ needs.CreateRelease.outputs.telemetryScopeJson }}

--- a/.github/workflows/CreateTestApp.yaml
+++ b/.github/workflows/CreateTestApp.yaml
@@ -1,4 +1,6 @@
-name: 'Create a new test app'
+﻿name: 'Create a new test app'
+
+run-name: "Create a new test app in [${{ github.ref_name }}]"
 
 on:
   workflow_dispatch:
@@ -33,7 +35,11 @@ permissions:
 
 defaults:
   run:
-    shell: PowerShell
+    shell: powershell
+
+env:
+  ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
+  ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
 
 jobs:
   CreateTestApp:
@@ -44,13 +50,15 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/WorkflowInitialize@main
         with:
+          shell: powershell
           eventId: "DO0095"
 
       - name: Creating a new test app
-        uses: microsoft/AL-Go-Actions/CreateApp@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/CreateApp@main
         with:
+          shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           project: ${{ github.event.inputs.project }}
           type: 'Test App'
@@ -62,7 +70,8 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/WorkflowPostProcess@main
         with:
+          shell: powershell
           eventId: "DO0095"
           telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}

--- a/.github/workflows/Current.yaml
+++ b/.github/workflows/Current.yaml
@@ -1,4 +1,4 @@
-name: ' Test Current'
+﻿name: ' Test Current'
 
 on:
   workflow_dispatch:
@@ -8,176 +8,77 @@ permissions:
 
 defaults:
   run:
-    shell: PowerShell
+    shell: powershell
+
+env:
+  workflowDepth: 1
+  ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
+  ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
 
 jobs:
   Initialization:
     runs-on: [ windows-latest ]
-    env:
-      workflowDepth: 0
     outputs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
       settings: ${{ steps.ReadSettings.outputs.SettingsJson }}
-      projects: ${{ steps.ReadSettings.outputs.ProjectsJson }}
-      projectCount: ${{ steps.ReadSettings.outputs.ProjectCount }}
       githubRunner: ${{ steps.ReadSettings.outputs.GitHubRunnerJson }}
-      projectDependenciesJson: ${{ steps.ReadSettings.outputs.ProjectDependenciesJson }}
-      buildOrderJson: ${{ steps.ReadSettings.outputs.BuildOrderJson }}
-      buildOrderDepth: ${{ steps.ReadSettings.outputs.BuildOrderDepth }}
+      githubRunnerShell: ${{ steps.ReadSettings.outputs.GitHubRunnerShell }}
+      projects: ${{ steps.determineProjectsToBuild.outputs.ProjectsJson }}
+      projectDependenciesJson: ${{ steps.determineProjectsToBuild.outputs.ProjectDependenciesJson }}
+      buildOrderJson: ${{ steps.determineProjectsToBuild.outputs.BuildOrderJson }}
+      workflowDepth: ${{ steps.DetermineWorkflowDepth.outputs.WorkflowDepth }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          lfs: true
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/WorkflowInitialize@main
         with:
+          shell: powershell
           eventId: "DO0101"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/ReadSettings@main
         with:
+          shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
-          getProjects: 'Y'
 
-      - name: Determine Build Order
-        if: env.WorkflowDepth > 1
-        id: BuildOrder
+      - name: Determine Workflow Depth
+        id: DetermineWorkflowDepth
         run: |
-          $ErrorActionPreference = "STOP"
-          $projects = '${{ steps.ReadSettings.outputs.ProjectsJson }}' | ConvertFrom-Json
-          $buildOrder = '${{ steps.ReadSettings.outputs.BuildOrderJson }}' | ConvertFrom-Json
-          $depth = ${{ steps.ReadSettings.outputs.BuildOrderDepth }}
-          $workflowDepth = ${{ steps.ReadSettings.outputs.WorkflowDepth }}
-          if ($depth -lt $workflowDepth) {
-            Write-Host "::Error::Project Dependencies depth is $depth. Workflow is only setup for $workflowDepth. You need to Run Update AL-Go System Files to update the workflows"
-            $host.SetShouldExit(1)
-          }
-          $step = $depth
-          $depth..1 | ForEach-Object {
-            $ps = @($buildOrder."$_" | Where-Object { $projects -contains $_ })
-            if ($ps.Count -eq 1) {
-              $projectsJSon = "[$($ps | ConvertTo-Json -compress)]"
-            }
-            else {
-              $projectsJSon = $ps | ConvertTo-Json -compress
-            }
-            if ($ps.Count -gt 0) {
-              Add-Content -Path $env:GITHUB_OUTPUT -Value "Projects$($step)Json=$projectsJson"
-              Add-Content -Path $env:GITHUB_OUTPUT -Value "Projects$($step)Count=$($ps.count)"
-              Write-Host "Projects$($step)Json=$projectsJson"
-              Write-Host "Projects$($step)Count=$($ps.count)"
-              $step--
-            }
-          }
-          while ($step -ge 1) {
-              Add-Content -Path $env:GITHUB_OUTPUT -Value "Projects$($step)Json="
-              Add-Content -Path $env:GITHUB_OUTPUT -Value "Projects$($step)Count=0"
-              Write-Host "Projects$($step)Json="
-              Write-Host "Projects$($step)Count=0"
-              $step--
-          }
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "WorkflowDepth=$($env:workflowDepth)"
+      
+      - name: Determine Projects To Build
+        id: determineProjectsToBuild
+        uses: businesscentralapps/tmp54nzkP-Actions/DetermineProjectsToBuild@main
+        with:
+          shell: powershell
+          maxBuildDepth: ${{ env.workflowDepth }}
 
   Build:
     needs: [ Initialization ]
-    if: ${{ needs.Initialization.outputs.projectCount > 0 }}
-    runs-on: ${{ fromJson(needs.Initialization.outputs.githubRunner) }}
+    if: (!failure()) && (!cancelled()) && fromJson(needs.Initialization.outputs.buildOrderJson)[0].projectsCount > 0
     strategy:
       matrix:
-        project: ${{ fromJson(needs.Initialization.outputs.projects) }}
+        include: ${{ fromJson(needs.Initialization.outputs.buildOrderJson)[0].buildDimensions }}
       fail-fast: false
-    name: Build ${{ matrix.project }}
-    outputs:
-      TestResultsArtifactsName: ${{ steps.calculateArtifactNames.outputs.TestResultsArtifactsName }}
-      BcptTestResultsArtifactsName: ${{ steps.calculateArtifactNames.outputs.BcptTestResultsArtifactsName }}
-      BuildOutputArtifactsName: ${{ steps.calculateArtifactNames.outputs.BuildOutputArtifactsName }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
-        with:
-          path: '${{ github.workspace }}\.dependencies'
-
-      - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v2.1
-        with:
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          project: ${{ matrix.project }}
-
-      - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v2.1
-        env:
-          secrets: ${{ toJson(secrets) }}
-        with:
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          settingsJson: ${{ env.Settings }}
-          secrets: 'licenseFileUrl,insiderSasToken,CodeSignCertificateUrl,CodeSignCertificatePassword,KeyVaultCertificateUrl,KeyVaultCertificatePassword,KeyVaultClientId,GitHubPackagesContext'
-
-      - name: Run pipeline
-        uses: microsoft/AL-Go-Actions/RunPipeline@v2.1
-        with:
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          Project: ${{ matrix.project }}
-          ProjectDependenciesJson: ${{ needs.Initialization.outputs.projectDependenciesJson }}
-          settingsJson: ${{ env.Settings }}
-          SecretsJson: ${{ env.RepoSecrets }}
-
-      - name: Calculate Artifact names
-        id: calculateArtifactNames
-        if: success() || failure()
-        run: |
-          $ErrorActionPreference = "STOP"
-          $settings = '${{ env.Settings }}' | ConvertFrom-Json
-          $project = '${{ matrix.project }}'
-          if ($project -eq ".") { $project = $settings.RepoName }
-          'TestResults','BcptTestResults','BuildOutput' | ForEach-Object {
-            $name = "$($_)ArtifactsName"
-            $value = "$($project.Replace('\','_'))-$_-Current-$([DateTime]::UtcNow.ToString('yyyyMMdd'))"
-            Add-Content -Path $env:GITHUB_OUTPUT -Value "$name=$value"
-            Add-Content -Path $env:GITHUB_ENV -Value "$name=$value"
-          }
-
-      - name: Publish artifacts - build output
-        uses: actions/upload-artifact@v3
-        if: (success() || failure()) && (hashFiles(format('{0}/BuildOutput.txt',matrix.project)) != '')
-        with:
-          name: ${{ env.buildOutputArtifactsName }}
-          path: '${{ matrix.project }}/BuildOutput.txt'
-          if-no-files-found: ignore
-
-      - name: Publish artifacts - test results
-        uses: actions/upload-artifact@v3
-        if: (success() || failure()) && (hashFiles(format('{0}/TestResults.xml',matrix.project)) != '')
-        with:
-          name: ${{ env.testResultsArtifactsName }}
-          path: '${{ matrix.project }}/TestResults.xml'
-          if-no-files-found: ignore
-
-      - name: Publish artifacts - bcpt test results
-        uses: actions/upload-artifact@v3
-        if: (success() || failure()) && (hashFiles(format('{0}/bcptTestResults.json',matrix.project)) != '')
-        with:
-          name: ${{ env.bcptTestResultsArtifactsName }}
-          path: '${{ matrix.project }}/bcptTestResults.json'
-          if-no-files-found: ignore
-
-      - name: Analyze Test Results
-        id: analyzeTestResults
-        if: success() || failure()
-        uses: microsoft/AL-Go-Actions/AnalyzeTests@v2.1
-        with:
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          Project: ${{ matrix.project }}
-
-      - name: Cleanup
-        if: always()
-        uses: microsoft/AL-Go-Actions/PipelineCleanup@v2.1
-        with:
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          Project: ${{ matrix.project }}
+    name: Build ${{ matrix.project }} - ${{ matrix.buildMode }}
+    uses: ./.github/workflows/_BuildALGoProject.yaml
+    secrets: inherit
+    with:
+      shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
+      runsOn: ${{ needs.Initialization.outputs.githubRunner }}
+      parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+      project: ${{ matrix.project }}
+      buildMode: ${{ matrix.buildMode }}
+      projectDependenciesJson: ${{ needs.Initialization.outputs.projectDependenciesJson }}
+      secrets: 'licenseFileUrl,insiderSasToken,codeSignCertificateUrl,codeSignCertificatePassword,keyVaultCertificateUrl,keyVaultCertificatePassword,keyVaultClientId,gitHubPackagesContext'
+      publishThisBuildArtifacts: ${{ needs.Initialization.outputs.workflowDepth > 1 }}
+      artifactsNameSuffix: 'Current'
 
   PostProcess:
     if: always()
@@ -189,7 +90,8 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/WorkflowPostProcess@main
         with:
+          shell: powershell
           eventId: "DO0101"
           telemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}

--- a/.github/workflows/IncrementVersionNumber.yaml
+++ b/.github/workflows/IncrementVersionNumber.yaml
@@ -1,4 +1,6 @@
-name: ' Increment Version Number'
+﻿name: ' Increment Version Number'
+
+run-name: "Increment Version Number in [${{ github.ref_name }}]"
 
 on:
   workflow_dispatch:
@@ -21,7 +23,11 @@ permissions:
 
 defaults:
   run:
-    shell: PowerShell
+    shell: powershell
+
+env:
+  ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
+  ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
 
 jobs:
   IncrementVersionNumber:
@@ -32,13 +38,15 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/WorkflowInitialize@main
         with:
+          shell: powershell
           eventId: "DO0096"
 
       - name: Increment Version Number
-        uses: microsoft/AL-Go-Actions/IncrementVersionNumber@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/IncrementVersionNumber@main
         with:
+          shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           project: ${{ github.event.inputs.project }}
           versionNumber: ${{ github.event.inputs.versionNumber }}
@@ -46,7 +54,8 @@ jobs:
   
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/WorkflowPostProcess@main
         with:
+          shell: powershell
           eventId: "DO0096"
           telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}

--- a/.github/workflows/NextMajor.yaml
+++ b/.github/workflows/NextMajor.yaml
@@ -1,4 +1,4 @@
-name: ' Test Next Major'
+﻿name: ' Test Next Major'
 
 on:
   workflow_dispatch:
@@ -8,176 +8,77 @@ permissions:
 
 defaults:
   run:
-    shell: PowerShell
+    shell: powershell
+
+env:
+  workflowDepth: 1
+  ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
+  ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
 
 jobs:
   Initialization:
     runs-on: [ windows-latest ]
-    env:
-      workflowDepth: 0
     outputs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
       settings: ${{ steps.ReadSettings.outputs.SettingsJson }}
-      projects: ${{ steps.ReadSettings.outputs.ProjectsJson }}
-      projectCount: ${{ steps.ReadSettings.outputs.ProjectCount }}
       githubRunner: ${{ steps.ReadSettings.outputs.GitHubRunnerJson }}
-      projectDependenciesJson: ${{ steps.ReadSettings.outputs.ProjectDependenciesJson }}
-      buildOrderJson: ${{ steps.ReadSettings.outputs.BuildOrderJson }}
-      buildOrderDepth: ${{ steps.ReadSettings.outputs.BuildOrderDepth }}
+      githubRunnerShell: ${{ steps.ReadSettings.outputs.GitHubRunnerShell }}
+      projects: ${{ steps.determineProjectsToBuild.outputs.ProjectsJson }}
+      projectDependenciesJson: ${{ steps.determineProjectsToBuild.outputs.ProjectDependenciesJson }}
+      buildOrderJson: ${{ steps.determineProjectsToBuild.outputs.BuildOrderJson }}
+      workflowDepth: ${{ steps.DetermineWorkflowDepth.outputs.WorkflowDepth }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          lfs: true
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/WorkflowInitialize@main
         with:
+          shell: powershell
           eventId: "DO0099"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/ReadSettings@main
         with:
+          shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
-          getProjects: 'Y'
 
-      - name: Determine Build Order
-        if: env.WorkflowDepth > 1
-        id: BuildOrder
+      - name: Determine Workflow Depth
+        id: DetermineWorkflowDepth
         run: |
-          $ErrorActionPreference = "STOP"
-          $projects = '${{ steps.ReadSettings.outputs.ProjectsJson }}' | ConvertFrom-Json
-          $buildOrder = '${{ steps.ReadSettings.outputs.BuildOrderJson }}' | ConvertFrom-Json
-          $depth = ${{ steps.ReadSettings.outputs.BuildOrderDepth }}
-          $workflowDepth = ${{ steps.ReadSettings.outputs.WorkflowDepth }}
-          if ($depth -lt $workflowDepth) {
-            Write-Host "::Error::Project Dependencies depth is $depth. Workflow is only setup for $workflowDepth. You need to Run Update AL-Go System Files to update the workflows"
-            $host.SetShouldExit(1)
-          }
-          $step = $depth
-          $depth..1 | ForEach-Object {
-            $ps = @($buildOrder."$_" | Where-Object { $projects -contains $_ })
-            if ($ps.Count -eq 1) {
-              $projectsJSon = "[$($ps | ConvertTo-Json -compress)]"
-            }
-            else {
-              $projectsJSon = $ps | ConvertTo-Json -compress
-            }
-            if ($ps.Count -gt 0) {
-              Add-Content -Path $env:GITHUB_OUTPUT -Value "Projects$($step)Json=$projectsJson"
-              Add-Content -Path $env:GITHUB_OUTPUT -Value "Projects$($step)Count=$($ps.count)"
-              Write-Host "Projects$($step)Json=$projectsJson"
-              Write-Host "Projects$($step)Count=$($ps.count)"
-              $step--
-            }
-          }
-          while ($step -ge 1) {
-              Add-Content -Path $env:GITHUB_OUTPUT -Value "Projects$($step)Json="
-              Add-Content -Path $env:GITHUB_OUTPUT -Value "Projects$($step)Count=0"
-              Write-Host "Projects$($step)Json="
-              Write-Host "Projects$($step)Count=0"
-              $step--
-          }
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "WorkflowDepth=$($env:workflowDepth)"
+          
+      - name: Determine Projects To Build
+        id: determineProjectsToBuild
+        uses: businesscentralapps/tmp54nzkP-Actions/DetermineProjectsToBuild@main
+        with:
+          shell: powershell
+          maxBuildDepth: ${{ env.workflowDepth }}
 
   Build:
     needs: [ Initialization ]
-    if: ${{ needs.Initialization.outputs.projectCount > 0 }}
-    runs-on: ${{ fromJson(needs.Initialization.outputs.githubRunner) }}
+    if: (!failure()) && (!cancelled()) && fromJson(needs.Initialization.outputs.buildOrderJson)[0].projectsCount > 0
     strategy:
       matrix:
-        project: ${{ fromJson(needs.Initialization.outputs.projects) }}
+        include: ${{ fromJson(needs.Initialization.outputs.buildOrderJson)[0].buildDimensions }}
       fail-fast: false
-    name: Build ${{ matrix.project }}
-    outputs:
-      TestResultsArtifactsName: ${{ steps.calculateArtifactNames.outputs.TestResultsArtifactsName }}
-      BcptTestResultsArtifactsName: ${{ steps.calculateArtifactNames.outputs.BcptTestResultsArtifactsName }}
-      BuildOutputArtifactsName: ${{ steps.calculateArtifactNames.outputs.BuildOutputArtifactsName }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
-        with:
-          path: '${{ github.workspace }}\.dependencies'
-
-      - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v2.1
-        with:
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          project: ${{ matrix.project }}
-
-      - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v2.1
-        env:
-          secrets: ${{ toJson(secrets) }}
-        with:
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          settingsJson: ${{ env.Settings }}
-          secrets: 'licenseFileUrl,insiderSasToken,CodeSignCertificateUrl,CodeSignCertificatePassword,KeyVaultCertificateUrl,KeyVaultCertificatePassword,KeyVaultClientId,GitHubPackagesContext'
-
-      - name: Run pipeline
-        uses: microsoft/AL-Go-Actions/RunPipeline@v2.1
-        with:
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          Project: ${{ matrix.project }}
-          ProjectDependenciesJson: ${{ needs.Initialization.outputs.projectDependenciesJson }}
-          settingsJson: ${{ env.Settings }}
-          SecretsJson: ${{ env.RepoSecrets }}
-
-      - name: Calculate Artifact names
-        id: calculateArtifactNames
-        if: success() || failure()
-        run: |
-          $ErrorActionPreference = "STOP"
-          $settings = '${{ env.Settings }}' | ConvertFrom-Json
-          $project = '${{ matrix.project }}'
-          if ($project -eq ".") { $project = $settings.RepoName }
-          'TestResults','BcptTestResults','BuildOutput' | ForEach-Object {
-            $name = "$($_)ArtifactsName"
-            $value = "$($project.Replace('\','_'))-$_-NextMajor-$([DateTime]::UtcNow.ToString('yyyyMMdd'))"
-            Add-Content -Path $env:GITHUB_OUTPUT -Value "$name=$value"
-            Add-Content -Path $env:GITHUB_ENV -Value "$name=$value"
-          }
-
-      - name: Publish artifacts - build output
-        uses: actions/upload-artifact@v3
-        if: (success() || failure()) && (hashFiles(format('{0}/BuildOutput.txt',matrix.project)) != '')
-        with:
-          name: ${{ env.buildOutputArtifactsName }}
-          path: '${{ matrix.project }}/BuildOutput.txt'
-          if-no-files-found: ignore
-
-      - name: Publish artifacts - test results
-        uses: actions/upload-artifact@v3
-        if: (success() || failure()) && (hashFiles(format('{0}/TestResults.xml',matrix.project)) != '')
-        with:
-          name: ${{ env.testResultsArtifactsName }}
-          path: '${{ matrix.project }}/TestResults.xml'
-          if-no-files-found: ignore
-
-      - name: Publish artifacts - bcpt test results
-        uses: actions/upload-artifact@v3
-        if: (success() || failure()) && (hashFiles(format('{0}/bcptTestResults.json',matrix.project)) != '')
-        with:
-          name: ${{ env.bcptTestResultsArtifactsName }}
-          path: '${{ matrix.project }}/bcptTestResults.json'
-          if-no-files-found: ignore
-
-      - name: Analyze Test Results
-        id: analyzeTestResults
-        if: success() || failure()
-        uses: microsoft/AL-Go-Actions/AnalyzeTests@v2.1
-        with:
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          Project: ${{ matrix.project }}
-
-      - name: Cleanup
-        if: always()
-        uses: microsoft/AL-Go-Actions/PipelineCleanup@v2.1
-        with:
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          Project: ${{ matrix.project }}
+    name: Build ${{ matrix.project }} - ${{ matrix.buildMode }}
+    uses: ./.github/workflows/_BuildALGoProject.yaml
+    secrets: inherit
+    with:
+      shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
+      runsOn: ${{ needs.Initialization.outputs.githubRunner }}
+      parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+      project: ${{ matrix.project }}
+      buildMode: ${{ matrix.buildMode }}
+      projectDependenciesJson: ${{ needs.Initialization.outputs.projectDependenciesJson }}
+      secrets: 'licenseFileUrl,insiderSasToken,codeSignCertificateUrl,codeSignCertificatePassword,keyVaultCertificateUrl,keyVaultCertificatePassword,keyVaultClientId,gitHubPackagesContext'
+      publishThisBuildArtifacts: ${{ needs.Initialization.outputs.workflowDepth > 1 }}
+      artifactsNameSuffix: 'NextMajor'
 
   PostProcess:
     if: always()
@@ -189,7 +90,8 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/WorkflowPostProcess@main
         with:
+          shell: powershell
           eventId: "DO0099"
           telemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}

--- a/.github/workflows/NextMinor.yaml
+++ b/.github/workflows/NextMinor.yaml
@@ -1,4 +1,4 @@
-name: ' Test Next Minor'
+﻿name: ' Test Next Minor'
 
 on:
   workflow_dispatch:
@@ -8,176 +8,77 @@ permissions:
 
 defaults:
   run:
-    shell: PowerShell
+    shell: powershell
+
+env:
+  workflowDepth: 1
+  ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
+  ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
 
 jobs:
   Initialization:
     runs-on: [ windows-latest ]
-    env:
-      workflowDepth: 0
     outputs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
       settings: ${{ steps.ReadSettings.outputs.SettingsJson }}
-      projects: ${{ steps.ReadSettings.outputs.ProjectsJson }}
-      projectCount: ${{ steps.ReadSettings.outputs.ProjectCount }}
       githubRunner: ${{ steps.ReadSettings.outputs.GitHubRunnerJson }}
-      projectDependenciesJson: ${{ steps.ReadSettings.outputs.ProjectDependenciesJson }}
-      buildOrderJson: ${{ steps.ReadSettings.outputs.BuildOrderJson }}
-      buildOrderDepth: ${{ steps.ReadSettings.outputs.BuildOrderDepth }}
+      githubRunnerShell: ${{ steps.ReadSettings.outputs.GitHubRunnerShell }}
+      projects: ${{ steps.determineProjectsToBuild.outputs.ProjectsJson }}
+      projectDependenciesJson: ${{ steps.determineProjectsToBuild.outputs.ProjectDependenciesJson }}
+      buildOrderJson: ${{ steps.determineProjectsToBuild.outputs.BuildOrderJson }}
+      workflowDepth: ${{ steps.DetermineWorkflowDepth.outputs.WorkflowDepth }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          lfs: true
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/WorkflowInitialize@main
         with:
+          shell: powershell
           eventId: "DO0100"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/ReadSettings@main
         with:
+          shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
-          getProjects: 'Y'
 
-      - name: Determine Build Order
-        if: env.WorkflowDepth > 1
-        id: BuildOrder
+      - name: Determine Workflow Depth
+        id: DetermineWorkflowDepth
         run: |
-          $ErrorActionPreference = "STOP"
-          $projects = '${{ steps.ReadSettings.outputs.ProjectsJson }}' | ConvertFrom-Json
-          $buildOrder = '${{ steps.ReadSettings.outputs.BuildOrderJson }}' | ConvertFrom-Json
-          $depth = ${{ steps.ReadSettings.outputs.BuildOrderDepth }}
-          $workflowDepth = ${{ steps.ReadSettings.outputs.WorkflowDepth }}
-          if ($depth -lt $workflowDepth) {
-            Write-Host "::Error::Project Dependencies depth is $depth. Workflow is only setup for $workflowDepth. You need to Run Update AL-Go System Files to update the workflows"
-            $host.SetShouldExit(1)
-          }
-          $step = $depth
-          $depth..1 | ForEach-Object {
-            $ps = @($buildOrder."$_" | Where-Object { $projects -contains $_ })
-            if ($ps.Count -eq 1) {
-              $projectsJSon = "[$($ps | ConvertTo-Json -compress)]"
-            }
-            else {
-              $projectsJSon = $ps | ConvertTo-Json -compress
-            }
-            if ($ps.Count -gt 0) {
-              Add-Content -Path $env:GITHUB_OUTPUT -Value "Projects$($step)Json=$projectsJson"
-              Add-Content -Path $env:GITHUB_OUTPUT -Value "Projects$($step)Count=$($ps.count)"
-              Write-Host "Projects$($step)Json=$projectsJson"
-              Write-Host "Projects$($step)Count=$($ps.count)"
-              $step--
-            }
-          }
-          while ($step -ge 1) {
-              Add-Content -Path $env:GITHUB_OUTPUT -Value "Projects$($step)Json="
-              Add-Content -Path $env:GITHUB_OUTPUT -Value "Projects$($step)Count=0"
-              Write-Host "Projects$($step)Json="
-              Write-Host "Projects$($step)Count=0"
-              $step--
-          }
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "WorkflowDepth=$($env:workflowDepth)"
+          
+      - name: Determine Projects To Build
+        id: determineProjectsToBuild
+        uses: businesscentralapps/tmp54nzkP-Actions/DetermineProjectsToBuild@main
+        with:
+          shell: powershell
+          maxBuildDepth: ${{ env.workflowDepth }}
 
   Build:
     needs: [ Initialization ]
-    if: ${{ needs.Initialization.outputs.projectCount > 0 }}
-    runs-on: ${{ fromJson(needs.Initialization.outputs.githubRunner) }}
+    if: (!failure()) && (!cancelled()) && fromJson(needs.Initialization.outputs.buildOrderJson)[0].projectsCount > 0
     strategy:
       matrix:
-        project: ${{ fromJson(needs.Initialization.outputs.projects) }}
+        include: ${{ fromJson(needs.Initialization.outputs.buildOrderJson)[0].buildDimensions }}
       fail-fast: false
-    name: Build ${{ matrix.project }}
-    outputs:
-      TestResultsArtifactsName: ${{ steps.calculateArtifactNames.outputs.TestResultsArtifactsName }}
-      BcptTestResultsArtifactsName: ${{ steps.calculateArtifactNames.outputs.BcptTestResultsArtifactsName }}
-      BuildOutputArtifactsName: ${{ steps.calculateArtifactNames.outputs.BuildOutputArtifactsName }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
-        with:
-          path: '${{ github.workspace }}\.dependencies'
-
-      - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v2.1
-        with:
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          project: ${{ matrix.project }}
-
-      - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v2.1
-        env:
-          secrets: ${{ toJson(secrets) }}
-        with:
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          settingsJson: ${{ env.Settings }}
-          secrets: 'licenseFileUrl,insiderSasToken,CodeSignCertificateUrl,CodeSignCertificatePassword,KeyVaultCertificateUrl,KeyVaultCertificatePassword,KeyVaultClientId,GitHubPackagesContext'
-
-      - name: Run pipeline
-        uses: microsoft/AL-Go-Actions/RunPipeline@v2.1
-        with:
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          Project: ${{ matrix.project }}
-          ProjectDependenciesJson: ${{ needs.Initialization.outputs.projectDependenciesJson }}
-          settingsJson: ${{ env.Settings }}
-          SecretsJson: ${{ env.RepoSecrets }}
-
-      - name: Calculate Artifact names
-        id: calculateArtifactNames
-        if: success() || failure()
-        run: |
-          $ErrorActionPreference = "STOP"
-          $settings = '${{ env.Settings }}' | ConvertFrom-Json
-          $project = '${{ matrix.project }}'
-          if ($project -eq ".") { $project = $settings.RepoName }
-          'TestResults','BcptTestResults','BuildOutput' | ForEach-Object {
-            $name = "$($_)ArtifactsName"
-            $value = "$($project.Replace('\','_'))-$_-NextMinor-$([DateTime]::UtcNow.ToString('yyyyMMdd'))"
-            Add-Content -Path $env:GITHUB_OUTPUT -Value "$name=$value"
-            Add-Content -Path $env:GITHUB_ENV -Value "$name=$value"
-          }
-
-      - name: Publish artifacts - build output
-        uses: actions/upload-artifact@v3
-        if: (success() || failure()) && (hashFiles(format('{0}/BuildOutput.txt',matrix.project)) != '')
-        with:
-          name: ${{ env.buildOutputArtifactsName }}
-          path: '${{ matrix.project }}/BuildOutput.txt'
-          if-no-files-found: ignore
-
-      - name: Publish artifacts - test results
-        uses: actions/upload-artifact@v3
-        if: (success() || failure()) && (hashFiles(format('{0}/TestResults.xml',matrix.project)) != '')
-        with:
-          name: ${{ env.testResultsArtifactsName }}
-          path: '${{ matrix.project }}/TestResults.xml'
-          if-no-files-found: ignore
-
-      - name: Publish artifacts - bcpt test results
-        uses: actions/upload-artifact@v3
-        if: (success() || failure()) && (hashFiles(format('{0}/bcptTestResults.json',matrix.project)) != '')
-        with:
-          name: ${{ env.bcptTestResultsArtifactsName }}
-          path: '${{ matrix.project }}/bcptTestResults.json'
-          if-no-files-found: ignore
-
-      - name: Analyze Test Results
-        id: analyzeTestResults
-        if: success() || failure()
-        uses: microsoft/AL-Go-Actions/AnalyzeTests@v2.1
-        with:
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          Project: ${{ matrix.project }}
-
-      - name: Cleanup
-        if: always()
-        uses: microsoft/AL-Go-Actions/PipelineCleanup@v2.1
-        with:
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          Project: ${{ matrix.project }}
+    name: Build ${{ matrix.project }} - ${{ matrix.buildMode }}
+    uses: ./.github/workflows/_BuildALGoProject.yaml
+    secrets: inherit
+    with:
+      shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
+      runsOn: ${{ needs.Initialization.outputs.githubRunner }}
+      parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+      project: ${{ matrix.project }}
+      buildMode: ${{ matrix.buildMode }}
+      projectDependenciesJson: ${{ needs.Initialization.outputs.projectDependenciesJson }}
+      secrets: 'licenseFileUrl,insiderSasToken,codeSignCertificateUrl,codeSignCertificatePassword,keyVaultCertificateUrl,keyVaultCertificatePassword,keyVaultClientId,gitHubPackagesContext'
+      publishThisBuildArtifacts: ${{ needs.Initialization.outputs.workflowDepth > 1 }}
+      artifactsNameSuffix: 'NextMinor'
 
   PostProcess:
     if: always()
@@ -189,7 +90,8 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/WorkflowPostProcess@main
         with:
+          shell: powershell
           eventId: "DO0100"
           telemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}

--- a/.github/workflows/PublishToAppSource.yaml
+++ b/.github/workflows/PublishToAppSource.yaml
@@ -1,4 +1,4 @@
-name: ' Publish To AppSource'
+﻿name: ' Publish To AppSource'
 
 on:
   workflow_dispatch:
@@ -7,6 +7,10 @@ on:
         description: App version to deliver to AppSource (current, prerelease, draft, latest or version number)
         required: false
         default: 'current'
+      projects:
+        description: Projects to publish to AppSource if the repository is multi-project. Default is *, which will publish all projects to AppSource.
+        required: false
+        default: '*'
       GoLive:
         description: Promote AppSource App to go live if it passes technical validation? (Y/N)
         required: false
@@ -18,7 +22,11 @@ permissions:
 
 defaults:
   run:
-    shell: PowerShell
+    shell: powershell
+
+env:
+  ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
+  ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
 
 jobs:
   Initialization:
@@ -31,8 +39,9 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/WorkflowInitialize@main
         with:
+          shell: powershell
           eventId: "DO0103"
 
   Deliver:
@@ -44,35 +53,39 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/ReadSettings@main
         with:
+          shell: powershell
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
 
       - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/ReadSecrets@main
         env:
           secrets: ${{ toJson(secrets) }}
         with:
+          shell: powershell
           settingsJson: ${{ env.Settings }}
-          secrets: 'AppSourceContext'
+          secrets: 'appSourceContext'
 
       - name: DeliveryContext
         id: deliveryContext
         run: |
           $ErrorActionPreference = "STOP"
-          $contextName = 'AppSourceContext'
+          Set-StrictMode -version 2.0
+          $contextName = 'appSourceContext'
           $deliveryContext = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String([System.Environment]::GetEnvironmentVariable($contextName)))
           Add-Content -Path $env:GITHUB_OUTPUT -Value "deliveryContext=$deliveryContext"
           Write-Host "deliveryContext=$deliveryContext"
 
       - name: Deliver
-        uses: microsoft/AL-Go-Actions/Deliver@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/Deliver@main
         env:
           deliveryContext: '${{ steps.deliveryContext.outputs.deliveryContext }}'
         with:
+          shell: powershell
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
           type: 'Release'
-          projects: '*'
+          projects: ${{ github.event.inputs.projects }}
           deliveryTarget: 'AppSource'
           artifacts: ${{ github.event.inputs.appVersion }}
           goLive: ${{ github.event.inputs.goLive }}
@@ -87,7 +100,8 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/WorkflowPostProcess@main
         with:
+          shell: powershell
           eventId: "DO0103"
           telemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}

--- a/.github/workflows/PublishToEnvironment.yaml
+++ b/.github/workflows/PublishToEnvironment.yaml
@@ -1,4 +1,4 @@
-name: ' Publish To Environment'
+﻿name: ' Publish To Environment'
 
 on:
   workflow_dispatch:
@@ -17,7 +17,11 @@ permissions:
 
 defaults:
   run:
-    shell: PowerShell
+    shell: powershell
+
+env:
+  ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
+  ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
 
 jobs:
   Initialization:
@@ -27,32 +31,91 @@ jobs:
       settings: ${{ steps.ReadSettings.outputs.SettingsJson }}
       environments: ${{ steps.ReadSettings.outputs.EnvironmentsJson }}
       environmentCount: ${{ steps.ReadSettings.outputs.EnvironmentCount }}
+      unknownEnvironment: ${{ steps.ReadSettings.outputs.UnknownEnvironment }}
+      deviceCode: ${{ steps.Authenticate.outputs.deviceCode }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/WorkflowInitialize@main
         with:
+          shell: powershell
           eventId: "DO0097"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/ReadSettings@main
         with:
+          shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           getEnvironments: ${{ github.event.inputs.environmentName }}
           includeProduction: 'Y'
 
+      - name: EnvName
+        id: envName
+        if: steps.ReadSettings.outputs.UnknownEnvironment == 1
+        run: |
+          $ErrorActionPreference = "STOP"
+          Set-StrictMode -version 2.0
+          $envName = '${{ fromJson(steps.ReadSettings.outputs.environmentsJson).matrix.include[0].environment }}'.split(' ')[0]
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
+
+      - name: Read secrets
+        uses: businesscentralapps/tmp54nzkP-Actions/ReadSecrets@main
+        if: steps.ReadSettings.outputs.UnknownEnvironment == 1
+        env:
+          secrets: ${{ toJson(secrets) }}
+        with:
+          shell: powershell
+          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          settingsJson: ${{ env.Settings }}
+          secrets: '${{ steps.envName.outputs.envName }}-AuthContext,${{ steps.envName.outputs.envName }}_AuthContext,AuthContext'
+
+      - name: Authenticate
+        id: Authenticate
+        if: steps.ReadSettings.outputs.UnknownEnvironment == 1
+        run: |
+          $envName = '${{ steps.envName.outputs.envName }}'
+          $secretName = ''
+          $authContext = $null
+          "$($envName)-AuthContext", "$($envName)_AuthContext", "AuthContext" | ForEach-Object {
+            if (!($authContext)) {
+              $authContext = [System.Environment]::GetEnvironmentVariable($_)
+              if ($authContext) {
+                Write-Host "Using $_ secret as AuthContext"
+                $secretName = $_
+              }
+            }            
+          }
+          if ($authContext) {
+            Write-Host "AuthContext provided in secret $secretName!"
+            Set-Content -Path $ENV:GITHUB_STEP_SUMMARY -value "AuthContext was provided in a secret called $secretName. Using this information for authentication."
+          }
+          else {
+            Write-Host "No AuthContext provided for $envName, initiating Device Code flow"
+            $ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
+            $webClient = New-Object System.Net.WebClient
+            $webClient.DownloadFile('https://raw.githubusercontent.com/businesscentralapps/tmp54nzkP-Actions/main/AL-Go-Helper.ps1', $ALGoHelperPath)
+            . $ALGoHelperPath
+            $BcContainerHelperPath = DownloadAndImportBcContainerHelper -baseFolder $ENV:GITHUB_WORKSPACE
+            $authContext = New-BcAuthContext -includeDeviceLogin -deviceLoginTimeout ([TimeSpan]::FromSeconds(0))
+            CleanupAfterBcContainerHelper -bcContainerHelperPath $bcContainerHelperPath
+            Set-Content -Path $ENV:GITHUB_STEP_SUMMARY -value "AL-Go needs access to the Business Central Environment $('${{ steps.envName.outputs.envName }}'.Split(' ')[0]) and could not locate a secret called ${{ steps.envName.outputs.envName }}_AuthContext`n`n$($authContext.message)"
+            Add-Content -Path $env:GITHUB_OUTPUT -Value "deviceCode=$($authContext.deviceCode)"
+          }
+
   Deploy:
     needs: [ Initialization ]
-    if: ${{ needs.Initialization.outputs.environmentCount > 0 }}
+    if: needs.Initialization.outputs.environmentCount > 0
     strategy: ${{ fromJson(needs.Initialization.outputs.environments) }}
     runs-on: ${{ fromJson(matrix.os) }}
     name: Deploy to ${{ matrix.environment }}
     environment:
       name: ${{ matrix.environment }}
+    env:
+      deviceCode: ${{ needs.Initialization.outputs.deviceCode }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -61,31 +124,46 @@ jobs:
         id: envName
         run: |
           $ErrorActionPreference = "STOP"
+          Set-StrictMode -version 2.0
           $envName = '${{ matrix.environment }}'.split(' ')[0]
           Add-Content -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/ReadSettings@main
+        with:
+          shell: powershell
 
       - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/ReadSecrets@main
         env:
           secrets: ${{ toJson(secrets) }}
         with:
+          shell: powershell
           settingsJson: ${{ env.Settings }}
-          secrets: '${{ steps.envName.outputs.envName }}-AuthContext,${{ steps.envName.outputs.envName }}_AuthContext,AuthContext,${{ steps.envName.outputs.envName }}-EnvironmentName,${{ steps.envName.outputs.envName }}_EnvironmentName,EnvironmentName,Projects'
+          secrets: '${{ steps.envName.outputs.envName }}-AuthContext,${{ steps.envName.outputs.envName }}_AuthContext,AuthContext,${{ steps.envName.outputs.envName }}-EnvironmentName,${{ steps.envName.outputs.envName }}_EnvironmentName,EnvironmentName,projects'
 
       - name: AuthContext
         id: authContext
         run: |
           $ErrorActionPreference = "STOP"
+          Set-StrictMode -version 2.0
           $envName = '${{ steps.envName.outputs.envName }}'
+          $deployToSettingStr = [System.Environment]::GetEnvironmentVariable("DeployTo$envName")
+          if ($deployToSettingStr) {
+            $deployToSetting = $deployToSettingStr | ConvertFrom-Json
+          }
+          else {
+            $deployToSetting = [PSCustomObject]@{}
+          }
           $authContext = $null
+          if ($env:deviceCode) {
+            $authContext = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes("{""deviceCode"":""$($env:deviceCode)""}"))
+          }
           "$($envName)-AuthContext", "$($envName)_AuthContext", "AuthContext" | ForEach-Object {
             if (!($authContext)) {
               $authContext = [System.Environment]::GetEnvironmentVariable($_)
               if ($authContext) {
-                Write-Host "Using $_ secret"
+                Write-Host "Using $_ secret as AuthContext"
               }
             }            
           }
@@ -93,43 +171,57 @@ jobs:
             Write-Host "::Error::No AuthContext provided"
             exit 1
           }
-          $environmentName = $null
-          "$($envName)-EnvironmentName", "$($envName)_EnvironmentName", "EnvironmentName" | ForEach-Object {
-            if (!($EnvironmentName)) {
-              $EnvironmentName = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String([System.Environment]::GetEnvironmentVariable($_)))
-              if ($EnvironmentName) {
-                Write-Host "Using $_ secret"
-              }
-            }            
+          if (("$deployToSetting" -ne "") -and $deployToSetting.PSObject.Properties.name -eq "EnvironmentName") {
+            $environmentName = $deployToSetting.EnvironmentName
+          }
+          else {
+            $environmentName = $null
+            "$($envName)-EnvironmentName", "$($envName)_EnvironmentName", "EnvironmentName" | ForEach-Object {
+              if (!($EnvironmentName)) {
+                $EnvironmentName = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String([System.Environment]::GetEnvironmentVariable($_)))
+                if ($EnvironmentName) {
+                  Write-Host "Using $_ secret as EnvironmentName"
+                  Write-Host "Please consider using the DeployTo$_ setting instead, where you can specify EnvironmentName, projects and branches"
+                }
+              }            
+            }
           }
           if (!($environmentName)) {
             $environmentName = '${{ steps.envName.outputs.envName }}'
           }
           $environmentName = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes(($environmentName + '${{ matrix.environment }}'.SubString($envName.Length)).ToUpperInvariant()))
-
-          $projects = [System.Environment]::GetEnvironmentVariable("$($envName)-Projects")
-          if (-not $projects) {
-            $projects = [System.Environment]::GetEnvironmentVariable("$($envName)_Projects")
+          if (("$deployToSetting" -ne "") -and $deployToSetting.PSObject.Properties.name -eq "projects") {
+            $projects = $deployToSetting.projects
+          }
+          else {
+            $projects = [System.Environment]::GetEnvironmentVariable("$($envName)-projects")
             if (-not $projects) {
-              $projects = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String([System.Environment]::GetEnvironmentVariable('projects')))
+              $projects = [System.Environment]::GetEnvironmentVariable("$($envName)_Projects")
+              if (-not $projects) {
+                $projects = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String([System.Environment]::GetEnvironmentVariable('projects')))
+              }
             }
           }
           if ($projects -eq '') {
             $projects = '*'
           }
-
+          elseif ($projects -ne '*') {
+            $buildProjects = '${{ needs.Initialization.outputs.projects }}' | ConvertFrom-Json
+            $projects = ($projects.Split(',') | Where-Object { $buildProjects -contains $_ }) -join ','
+          }
           Add-Content -Path $env:GITHUB_OUTPUT -Value "authContext=$authContext"
-          Write-Host "authContext=$authContext"
           Add-Content -Path $env:GITHUB_OUTPUT -Value "environmentName=$environmentName"
-          Write-Host "environmentName=$environmentName"
+          Write-Host "environmentName=$([System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($environmentName)))"
+          Write-Host "environmentName (as Base64)=$environmentName"
           Add-Content -Path $env:GITHUB_OUTPUT -Value "projects=$projects"
           Write-Host "projects=$projects"
 
       - name: Deploy
-        uses: microsoft/AL-Go-Actions/Deploy@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/Deploy@main
         env:
-          authContext: ${{ steps.authContext.outputs.authContext }}
+          AuthContext: ${{ steps.authContext.outputs.authContext }}
         with:
+          shell: powershell
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
           type: 'Publish'
           projects: ${{ steps.authContext.outputs.projects }}
@@ -146,7 +238,8 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/WorkflowPostProcess@main
         with:
+          shell: powershell
           eventId: "DO0097"
           telemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}

--- a/.github/workflows/PullRequestHandler.yaml
+++ b/.github/workflows/PullRequestHandler.yaml
@@ -1,84 +1,128 @@
-name: 'Pull Request Handler'
+﻿name: 'Pull Request Build'
 
 on:
-  pull_request:
+  pull_request_target:
     paths-ignore:
-      - '*.md'
-      - '*.ps1'
-      - '*.yaml'
+      - '**.md'
     branches: [ 'main' ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 defaults:
   run:
-    shell: PowerShell
+    shell: powershell
 
 permissions:
   contents: read
   actions: read
   pull-requests: read
 
+env:
+  workflowDepth: 1
+  ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
+  ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
+
 jobs:
-  PullRequestHandler:
+  PregateCheck:
+    if: github.event.pull_request.base.repo.full_name != github.event.pull_request.head.repo.full_name
     runs-on: [ windows-latest ]
     steps:
       - uses: actions/checkout@v3
-      
-      - name: Determine Changed Files
-        id: ChangedFiles
-        run: |
-          $ErrorActionPreference = "STOP"
-          $sb = [System.Text.StringBuilder]::new()
-          $headers = @{             
-              "Authorization" = 'token ${{ secrets.GITHUB_TOKEN }}'
-              "Accept" = "application/vnd.github.baptiste-preview+json"
-          }
-          $baseSHA = '${{ github.event.pull_request.base.sha }}'
-          $headSHA = '${{ github.event.pull_request.head.sha }}'
-          $url = "$($ENV:GITHUB_API_URL)/repos/$($ENV:GITHUB_REPOSITORY)/compare/$baseSHA...$headSHA"
-          $response = Invoke-WebRequest -UseBasicParsing -Headers $headers -Uri $url | ConvertFrom-Json
-          $location = (Get-Location).path
-          $prfolder = [GUID]::NewGuid().ToString()
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "prfolder=$prfolder"
-          $prPath = Join-Path $location $prFolder
-          New-Item -Path $prPath -ItemType Directory | Out-Null
-          Write-Host "Files Changed:"
-          $response.files | ForEach-Object {
-            $filename = $_.filename
-            $status = $_.status
-            Write-Host "- $filename $status"
-            $path = Join-Path $location $filename
-            $newPath = Join-Path $prPath $filename
-            $newfolder = [System.IO.Path]::GetDirectoryName($newpath)
-            $extension = [System.IO.Path]::GetExtension($path)
-            $name = [System.IO.Path]::GetFileName($path)
-            if ('${{ github.event.pull_request.head.repo.full_name }}' -ne $ENV:GITHUB_REPOSITORY) {
-              if ($extension -eq '.ps1' -or $extension -eq '.yaml' -or $extension -eq '.yml' -or $name -eq "CODEOWNERS") {
-                throw "Pull Request containing changes to scripts, workflows or CODEOWNERS are not allowed from forks."
-              }
-            }
-            if (-not (Test-Path $newfolder)) {
-              New-Item $newfolder -ItemType Directory | Out-Null
-            }
-            if ($status -eq "renamed") {
-              Copy-Item -Path $path -Destination $newfolder -Force
-              $oldPath = Join-Path $prPath $_.previous_filename
-              $oldFolder = [System.IO.Path]::GetDirectoryName($oldpath)
-              if (-not (Test-Path $oldFolder)) {
-                New-Item $oldFolder -ItemType Directory | Out-Null
-              }
-              New-Item -Path "$oldPath.REMOVE" -itemType File | Out-Null
-            }
-            elseif ($status -eq "removed") {
-              New-Item -Path $newfolder -name "$name.REMOVE" -itemType File | Out-Null
-            }
-            else {
-              Copy-Item -Path $path -Destination $newfolder -Force
-            }
-          }
-          Set-Content -path (Join-Path $prPath "comment_id") -value '${{ steps.CreateComment.outputs.comment_id }}' -NoNewLine -Force
-
-      - name: Upload Changed Files
-        uses: actions/upload-artifact@v3
         with:
-          name: Pull_Request_Files
-          path: '${{ steps.ChangedFiles.outputs.prfolder }}/'
+          lfs: true
+          ref: refs/pull/${{ github.event.number }}/merge
+
+      - uses: businesscentralapps/tmp54nzkP-Actions/VerifyPRChanges@main
+        with:
+          baseSHA: ${{ github.event.pull_request.base.sha }}
+          headSHA: ${{ github.event.pull_request.head.sha }}
+          prbaseRepository: ${{ github.event.pull_request.base.repo.full_name }}
+
+  Initialization:
+    needs: [ PregateCheck ]
+    if: (!failure() && !cancelled())
+    runs-on: [ windows-latest ]
+    outputs:
+      telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+      settings: ${{ steps.ReadSettings.outputs.SettingsJson }}
+      githubRunner: ${{ steps.ReadSettings.outputs.GitHubRunnerJson }}
+      githubRunnerShell: ${{ steps.ReadSettings.outputs.GitHubRunnerShell }}
+      projects: ${{ steps.determineProjectsToBuild.outputs.ProjectsJson }}
+      projectDependenciesJson: ${{ steps.determineProjectsToBuild.outputs.ProjectDependenciesJson }}
+      buildOrderJson: ${{ steps.determineProjectsToBuild.outputs.BuildOrderJson }}
+      workflowDepth: ${{ steps.DetermineWorkflowDepth.outputs.WorkflowDepth }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          lfs: true
+          ref: refs/pull/${{ github.event.number }}/merge
+
+      - name: Initialize the workflow
+        id: init
+        uses: businesscentralapps/tmp54nzkP-Actions/WorkflowInitialize@main
+        with:
+          shell: powershell
+          eventId: "DO0104"
+
+      - name: Read settings
+        id: ReadSettings
+        uses: businesscentralapps/tmp54nzkP-Actions/ReadSettings@main
+        with:
+          shell: powershell
+          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          getEnvironments: '*'
+      
+      - name: Determine Workflow Depth
+        id: DetermineWorkflowDepth
+        run: |
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "WorkflowDepth=$($env:workflowDepth)"
+          
+      - name: Determine Projects To Build
+        id: determineProjectsToBuild
+        uses: businesscentralapps/tmp54nzkP-Actions/DetermineProjectsToBuild@main
+        with:
+          shell: powershell
+          maxBuildDepth: ${{ env.workflowDepth }}
+
+  Build:
+    needs: [ Initialization ]
+    if: (!failure()) && (!cancelled()) && fromJson(needs.Initialization.outputs.buildOrderJson)[0].projectsCount > 0
+    strategy:
+      matrix:
+        include: ${{ fromJson(needs.Initialization.outputs.buildOrderJson)[0].buildDimensions }}
+      fail-fast: false
+    name: Build ${{ matrix.project }} - ${{ matrix.buildMode }}
+    uses: ./.github/workflows/_BuildALGoProject.yaml
+    secrets: inherit
+    with:
+      shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
+      runsOn: ${{ needs.Initialization.outputs.githubRunner }}
+      checkoutRef: refs/pull/${{ github.event.number }}/merge
+      parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+      project: ${{ matrix.project }}
+      buildMode: ${{ matrix.buildMode }}
+      projectDependenciesJson: ${{ needs.Initialization.outputs.projectDependenciesJson }}
+      secrets: 'licenseFileUrl,insiderSasToken,keyVaultCertificateUrl,keyVaultCertificatePassword,keyVaultClientId,gitHubPackagesContext'
+      publishThisBuildArtifacts: ${{ needs.Initialization.outputs.workflowDepth > 1 }}
+
+  PostProcess:
+    runs-on: [ windows-latest ]
+    needs: [ Initialization, Build ]
+    if: (!cancelled())
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          lfs: true
+          ref: refs/pull/${{ github.event.number }}/merge
+
+      - name: Finalize the workflow
+        id: PostProcess
+        uses: businesscentralapps/tmp54nzkP-Actions/WorkflowPostProcess@main
+        with:
+          shell: powershell
+          eventId: "DO0104"
+          telemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}

--- a/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -1,10 +1,10 @@
-name: ' Update AL-Go System Files'
+﻿name: ' Update AL-Go System Files'
 
 on:
   workflow_dispatch:
     inputs:
       templateUrl:
-        description: Template Repository URL (current is https://github.com/microsoft/AL-Go-AppSource@v2.1)
+        description: Template Repository URL (current is https://github.com/businesscentralapps/tmp54nzkP-AppSource@main)
         required: false
         default: ''
       directCommit:
@@ -17,7 +17,11 @@ permissions:
 
 defaults:
   run:
-    shell: PowerShell
+    shell: powershell
+
+env:
+  ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
+  ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
 
 jobs:
   UpdateALGoSystemFiles:
@@ -28,34 +32,38 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/WorkflowInitialize@main
         with:
+          shell: powershell
           eventId: "DO0098"
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/ReadSettings@main
         with:
+          shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
-          get: KeyVaultName,GhTokenWorkflowSecretName,TemplateUrl
+          get: keyVaultName,ghTokenWorkflowSecretName,templateUrl
 
       - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/ReadSecrets@main
         env:
           secrets: ${{ toJson(secrets) }}
         with:
+          shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           settingsJson: ${{ env.Settings }}
           secrets: 'ghTokenWorkflow=${{ env.GHTOKENWORKFLOWSECRETNAME }}'
 
-      - name: Override TemplateUrl
+      - name: Override templateUrl
         env:
           templateUrl: ${{ github.event.inputs.templateUrl }}
         run: |
           $ErrorActionPreference = "STOP"
+          Set-StrictMode -version 2.0
           $templateUrl = $ENV:templateUrl
           if ($templateUrl) {
             Write-Host "Using Template Url: $templateUrl"
-            Add-Content -Path $env:GITHUB_ENV -Value "TemplateUrl=$templateUrl"
+            Add-Content -Path $env:GITHUB_ENV -Value "templateUrl=$templateUrl"
           }
 
       - name: Calculate DirectCommit
@@ -64,6 +72,7 @@ jobs:
           eventName: ${{ github.event_name }}
         run: |
           $ErrorActionPreference = "STOP"
+          Set-StrictMode -version 2.0
           $directCommit = $ENV:directCommit
           Write-Host $ENV:eventName
           if ($ENV:eventName -eq 'schedule') {
@@ -73,17 +82,19 @@ jobs:
           Add-Content -Path $env:GITHUB_ENV -Value "DirectCommit=$directCommit"
 
       - name: Update AL-Go system files
-        uses: microsoft/AL-Go-Actions/CheckForUpdates@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/CheckForUpdates@main
         with:
+          shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           token: ${{ env.ghTokenWorkflow }}
           Update: Y
-          templateUrl: ${{ env.TemplateUrl }}
+          templateUrl: ${{ env.templateUrl }}
           directCommit: ${{ env.directCommit }}
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v2.1
+        uses: businesscentralapps/tmp54nzkP-Actions/WorkflowPostProcess@main
         with:
+          shell: powershell
           eventId: "DO0098"
           telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}

--- a/.github/workflows/_BuildALGoProject.yaml
+++ b/.github/workflows/_BuildALGoProject.yaml
@@ -1,0 +1,245 @@
+﻿name: '_Build AL-GO project'
+
+run-name: 'Build project ${{ inputs.project }}'
+
+on:
+  workflow_call:
+    inputs:
+      shell:
+        description: Shell in which you want to run the action (powershell or pwsh)
+        required: false
+        default: powershell
+        type: string
+      runsOn: 
+        description: JSON-formatted string og the types of machine to run the build job on
+        required: true
+        type: string
+      checkoutRef:
+        description: Ref to checkout
+        required: false
+        default: ${{ github.ref }}
+        type: string
+      project:
+        description: Name of the built project
+        required: true
+        type: string
+      projectDependenciesJson:
+        description: Dependencies of the built project in compressed Json format
+        required: false
+        default: '{}'
+        type: string
+      buildMode:
+        description: Build mode used when building the artifacts
+        required: true
+        type: string
+      secrets:
+        description: A comma-separated string with the names of the secrets, required for the workflow.
+        required: false
+        default: ''
+        type: string
+      publishThisBuildArtifacts:
+        description: Flag indicating whether this build artifacts should be published
+        required: false
+        default: false
+        type: boolean
+      publishArtifacts:
+        description: Flag indicating whether the artifacts should be published
+        required: false
+        default: false
+        type: boolean
+      artifactsNameSuffix:
+        description: Suffix to add to the artifacts names
+        required: false
+        default: ''
+        type: string
+      signArtifacts:
+        description: Flag indicating whether the apps should be signed
+        required: false
+        default: false
+        type: boolean
+      useArtifactCache:
+        description: Flag determining whether to use the Artifacts Cache
+        required: false
+        default: false
+        type: boolean
+      parentTelemetryScopeJson:
+        description: Specifies the telemetry scope for the telemetry signal
+        required: false
+        type: string
+jobs:
+  BuildALGoProject:
+    runs-on: ${{ fromJson(inputs.runsOn) }}
+    steps:
+        - name: Checkout
+          uses: actions/checkout@v3
+          with:
+            ref: ${{ inputs.checkoutRef }}
+            lfs: true
+      
+        - name: Download thisbuild artifacts
+          if: inputs.publishThisBuildArtifacts
+          uses: actions/download-artifact@v3
+          with:
+            path: '.dependencies'
+
+        - name: Read settings
+          uses: businesscentralapps/tmp54nzkP-Actions/ReadSettings@main
+          with:
+            shell: ${{ inputs.shell }}
+            parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
+            project: ${{ inputs.project }}
+
+        - name: Read secrets
+          uses: businesscentralapps/tmp54nzkP-Actions/ReadSecrets@main
+          env:
+            secrets: ${{ toJson(secrets) }}
+          with:
+            shell: ${{ inputs.shell }}
+            parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
+            settingsJson: ${{ env.Settings }}
+            secrets: ${{ inputs.secrets }}
+
+        - name: Determine ArtifactUrl
+          uses: businesscentralapps/tmp54nzkP-Actions/DetermineArtifactUrl@main
+          id: determineArtifactUrl
+          with:
+            shell: ${{ inputs.shell }}
+            parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
+            project: ${{ inputs.project }}
+            settingsJson: ${{ env.Settings }}
+            secretsJson: ${{ env.RepoSecrets }}
+
+        - name: Cache Business Central Artifacts
+          if: env.useCompilerFolder == 'True' && inputs.useArtifactCache && steps.determineArtifactUrl.outputs.ArtifactCacheKey
+          uses: actions/cache@v3
+          with:
+            path: .artifactcache
+            key: ${{ steps.determineArtifactUrl.outputs.ArtifactCacheKey }}
+
+        - name: Run pipeline
+          id: RunPipeline
+          uses: businesscentralapps/tmp54nzkP-Actions/RunPipeline@main
+          env:
+            BuildMode: ${{ inputs.buildMode }}
+          with:
+            shell: ${{ inputs.shell }}
+            parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
+            project: ${{ inputs.project }}
+            projectDependenciesJson: ${{ inputs.projectDependenciesJson }}
+            settingsJson: ${{ env.Settings }}
+            secretsJson: ${{ env.RepoSecrets }}
+            buildMode: ${{ inputs.buildMode }}
+
+        - name: Sign
+          if: inputs.signArtifacts && env.doNotSignApps == 'False' && env.keyVaultCodesignCertificateName != ''
+          id: sign
+          uses: businesscentralapps/tmp54nzkP-Actions/Sign@main
+          with:
+            shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
+            azureCredentialsJson: ${{ secrets.AZURE_CREDENTIALS }}
+            settingsJson: ${{ env.Settings }}
+            pathToFiles: '${{ matrix.project }}/.buildartifacts/Apps/*.app'
+            parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+
+        - name: Calculate Artifact names
+          id: calculateArtifactsNames
+          uses: businesscentralapps/tmp54nzkP-Actions/CalculateArtifactNames@main
+          if: success() || failure()
+          with:
+            shell: ${{ inputs.shell }}
+            settingsJson: ${{ env.Settings }}
+            project: ${{ inputs.project }}
+            buildMode: ${{ inputs.buildMode }}
+            branchName: ${{ github.ref_name }}
+            suffix: ${{ inputs.artifactsNameSuffix }}
+
+        - name: Upload thisbuild artifacts - apps
+          if: inputs.publishThisBuildArtifacts
+          uses: actions/upload-artifact@v3
+          with:
+            name: ${{ steps.calculateArtifactsNames.outputs.ThisBuildAppsArtifactsName }}
+            path: '${{ inputs.project }}/.buildartifacts/Apps/'
+            if-no-files-found: ignore
+            retention-days: 1
+
+        - name: Upload thisbuild artifacts - test apps
+          if: inputs.publishThisBuildArtifacts
+          uses: actions/upload-artifact@v3
+          with:
+            name: ${{ steps.calculateArtifactsNames.outputs.ThisBuildTestAppsArtifactsName }}
+            path: '${{ inputs.project }}/.buildartifacts/TestApps/'
+            if-no-files-found: ignore
+            retention-days: 1
+        
+        - name: Publish artifacts - apps
+          uses: actions/upload-artifact@v3
+          if: inputs.publishArtifacts
+          with:
+            name: ${{ env.AppsArtifactsName }}
+            path: '${{ inputs.project }}/.buildartifacts/Apps/'
+            if-no-files-found: ignore
+
+        - name: Publish artifacts - dependencies
+          uses: actions/upload-artifact@v3
+          if: inputs.publishArtifacts
+          with:
+            name: ${{ env.DependenciesArtifactsName }}
+            path: '${{ inputs.project }}/.buildartifacts/Dependencies/'
+            if-no-files-found: ignore
+
+        - name: Publish artifacts - test apps
+          uses: actions/upload-artifact@v3
+          if: inputs.publishArtifacts
+          with:
+            name: ${{ env.TestAppsArtifactsName }}
+            path: '${{ inputs.project }}/.buildartifacts/TestApps/'
+            if-no-files-found: ignore
+
+        - name: Publish artifacts - build output
+          uses: actions/upload-artifact@v3
+          if: (success() || failure()) && (hashFiles(format('{0}/BuildOutput.txt',inputs.project)) != '')
+          with:
+            name: ${{ env.BuildOutputArtifactsName }}
+            path: '${{ inputs.project }}/BuildOutput.txt'
+            if-no-files-found: ignore
+
+        - name: Publish artifacts - container event log
+          uses: actions/upload-artifact@v3
+          if: (failure()) && (hashFiles(format('{0}/ContainerEventLog.evtx',inputs.project)) != '')
+          with:
+            name: ${{ env.ContainerEventLogArtifactsName }}
+            path: '${{ inputs.project }}/ContainerEventLog.evtx'
+            if-no-files-found: ignore
+
+        - name: Publish artifacts - test results
+          uses: actions/upload-artifact@v3
+          if: (success() || failure()) && (hashFiles(format('{0}/TestResults.xml',inputs.project)) != '')
+          with:
+            name: ${{ env.TestResultsArtifactsName }}
+            path: '${{ inputs.project }}/TestResults.xml'
+            if-no-files-found: ignore
+
+        - name: Publish artifacts - bcpt test results
+          uses: actions/upload-artifact@v3
+          if: (success() || failure()) && (hashFiles(format('{0}/bcptTestResults.json',inputs.project)) != '')
+          with:
+            name: ${{ env.BcptTestResultsArtifactsName }}
+            path: '${{ inputs.project }}/bcptTestResults.json'
+            if-no-files-found: ignore
+
+        - name: Analyze Test Results
+          id: analyzeTestResults
+          if: success() || failure()
+          uses: businesscentralapps/tmp54nzkP-Actions/AnalyzeTests@main
+          with:
+            shell: ${{ inputs.shell }}
+            parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
+            Project: ${{ inputs.project }}
+
+        - name: Cleanup
+          if: always()
+          uses: businesscentralapps/tmp54nzkP-Actions/PipelineCleanup@main
+          with:
+            shell: ${{ inputs.shell }}
+            parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
+            Project: ${{ inputs.project }}


### PR DESCRIPTION
## Preview

Note that when using the preview version of AL-Go for GitHub, you need to Update your AL-Go system files, as soon as possible when told to do so.

### Issues

Issue 542 Deploy Workflow fails

### New Settings
- `keyVaultCodesignCertificateName`:  With this setting you can delegate the codesigning to an Azure Key Vault. This can be useful if your certificate has to be stored in a Hardware Security Module

## v3.1

### Issues

Issue #446 Wrong NewLine character in Release Notes
Issue #453 DeliverToStorage - override fails reading secrets
Issue #434 Use gh auth token to get authentication token instead of gh auth status
Issue #501 The Create New App action will now use 22.0.0.0 as default application reference and include NoImplicitwith feature.


### New behavior

The following workflows:

- Create New App
- Create New Test App
- Create New Performance Test App
- Increment Version Number
- Add Existing App
- Create Online Development Environment

All these actions now uses the selected branch in the **Run workflow** dialog as the target for the Pull Request or Direct COMMIT.

### New Settings

- `UseCompilerFolder`: Setting useCompilerFolder to true causes your pipelines to use containerless compiling. Unless you also set `doNotPublishApps` to true, setting useCompilerFolder to true won't give you any performance advantage, since AL-Go for GitHub will still need to create a container in order to publish and test the apps. In the future, publishing and testing will be split from building and there will be other options for getting an instance of Business Central for publishing and testing. 
- `vsixFile`: vsixFile should be a direct download URL to the version of the AL Language extension you want to use for building the project or repo. By default, AL-Go will use the AL Language extension that comes with the Business Central Artifacts.

### New Workflows

- **_BuildALGoProject** is a reusable workflow that unites the steps for building an AL-Go projects. It has been reused in the following workflows: _CI/CD_, _Pull Request Build_, _NextMinor_, _NextMajor_ and _Current_.
The workflow appears under the _Actions_ tab in GitHub, but it is not actionable in any way.  

### New Actions

- **DetermineArtifactUrl** is used to determine which artifacts to use for building a project in CI/CD, PullRequestHandler, Current, NextMinor and NextMajor workflows.

### License File

With the changes to the CRONUS license in Business Central version 22, that license can in most cases be used as a developer license for AppSource Apps and it is no longer mandatory to specify a license file in AppSource App repositories.
Obviously, if you build and test your app for Business Central versions prior to 21, it will fail if you don't specify a licenseFileUrl secret.

## v3.0

### **NOTE:** When upgrading to this version
When upgrading to this version form earlier versions of AL-Go for GitHub, you will need to run the _Update AL-Go System Files_ workflow twice if you have the `useProjectDependencies` setting set to _true_.

### Publish to unknown environment
You can now run the **Publish To Environment** workflow without creating the environment in GitHub or settings up-front, just by specifying the name of a single environment in the Environment Name when running the workflow.
Subsequently, if an AuthContext secret hasn't been created for this environment, the Device Code flow authentication will be initiated from the Publish To Environment workflow and you can publish to the new environment without ever creating a secret.
Open Workflow details to get the device Code for authentication in the job summary for the initialize job.

### Create Online Dev. Environment
When running the **Create Online Dev. Environment** workflow without having the _adminCenterApiCredentials_ secret created, the workflow will intiate the deviceCode flow and allow you to authenticate to the Business Central Admin Center.
Open Workflow details to get the device Code for authentication in the job summary for the initialize job.

### Issues
- Issue #391 Create release action - CreateReleaseBranch error
- Issue 434 Building local DevEnv, downloading dependencies: Authentication fails when using "gh auth status"

### Changes to Pull Request Process
In v2.4 and earlier, the PullRequestHandler would trigger the CI/CD workflow to run the PR build.
Now, the PullRequestHandler will perform the build and the CI/CD workflow is only run on push (or manual dispatch) and will perform a complete build.

### Build modes per project
Build modes can now be specified per project

### New Actions
- **DetermineProjectsToBuild** is used to determine which projects to build in PullRequestHandler, CI/CD, Current, NextMinor and NextMajor workflows.
- **CalculateArtifactNames** is used to calculate artifact names in PullRequestHandler, CI/CD, Current, NextMinor and NextMajor workflows.
- **VerifyPRChanges** is used to verify whether a PR contains changes, which are not allowed from a fork.

## v2.4

### Issues
- Issue #171 create a workspace file when creating a project
- Issue #356 Publish to AppSource fails in multi project repo
- Issue #358 Publish To Environment Action stopped working in v2.3
- Issue #362 Support for EnableTaskScheduler
- Issue #360 Creating a release and deploying from a release branch
- Issue #371 'No previous release found' for builds on release branches
- Issue #376 CICD jobs that are triggered by the pull request trigger run directly to an error if title contains quotes

### Release Branches
**NOTE:** Release Branches are now only named after major.minor if the patch value is 0 in the release tag (which must be semver compatible)

This version contains a number of bug fixes to release branches, to ensure that the recommended branching strategy is fully supported. Bugs fixed includes:
- Release branches was named after the full tag (1.0.0), even though subsequent hotfixes released from this branch would be 1.0.x
- Release branches named 1.0 wasn't picked up as a release branch
- Release notes contained the wrong changelog
- The previous release was always set to be the first release from a release branch
- SemVerStr could not have 5 segments after the dash
- Release was created on the right SHA, but the release branch was created on the wrong SHA

Recommended branching strategy:

![Branching Strategy](https://raw.githubusercontent.com/microsoft/AL-Go/main/Scenarios/images/branchingstrategy.png)

### New Settings
New Project setting: EnableTaskScheduler in container executing tests and when setting up local development environment

### Support for GitHub variables: ALGoOrgSettings and ALGoRepoSettings
Recently, GitHub added support for variables, which you can define on your organization or your repository.
AL-Go now supports that you can define a GitHub variable called ALGoOrgSettings, which will work for all repositories (with access to the variable)
Org Settings will be applied before Repo settings and local repository settings files will override values in the org settings
You can also define a variable called ALGoRepoSettings on the repository, which will be applied after reading the Repo Settings file in the repo
Example for usage could be setup of branching strategies, versioning or an appDependencyProbingPaths to repositories which all repositories share.
appDependencyProbingPaths from settings variables are merged together with appDependencyProbingPaths defined in repositories

### Refactoring and tests
ReadSettings has been refactored to allow organization wide settings to be added as well. CI Tests have been added to cover ReadSettings.

## v2.3

### Issues
- Issue #312 Branching enhancements
- Issue #229 Create Release action tags wrong commit
- Issue #283 Create Release workflow uses deprecated actions
- Issue #319 Support for AssignPremiumPlan
- Issue #328 Allow multiple projects in AppSource App repo
- Issue #344 Deliver To AppSource on finding app.json for the app
- Issue #345 LocalDevEnv.ps1 can't Dowload the file license file

### New Settings
New Project setting: AssignPremiumPlan on user in container executing tests and when setting up local development environment
New Repo setting: unusedALGoSystemFiles is an array of AL-Go System Files, which won't be updated during Update AL-Go System Files. They will instead be removed. Use with care, as this can break the AL-Go for GitHub functionality and potentially leave your repo no longer functional.

### Build modes support
AL-Go projects can now be built in different modes, by specifying the _buildModes_ setting in AL-Go-Settings.json. Read more about build modes in the [Basic Repository settings](https://github.com/microsoft/AL-Go/blob/main/Scenarios/settings.md#basic-repository-settings).

### LocalDevEnv / CloudDevEnv
With the support for PowerShell 7 in BcContainerHelper, the scripts LocalDevEnv and CloudDevEnv (placed in the .AL-Go folder) for creating development environments have been modified to run inside VS Code instead of spawning a new powershell 5.1 session.

### Continuous Delivery
Continuous Delivery can now run from other branches than main. By specifying a property called branches, containing an array of branches in the deliveryContext json construct, the artifacts generated from this branch are also delivered. The branch specification can include wildcards (like release/*). Default is main, i.e. no changes to functionality.

### Continuous Deployment
Continuous Deployment can now run from other branches than main. By creating a repo setting (.github/AL-Go-Settings.json) called **`<environmentname>-Branches`**, which is an array of branches, which will deploy the generated artifacts to this environment. The branch specification can include wildcards (like release/*), although this probably won't be used a lot in continuous deployment. Default is main, i.e. no changes to functionality.

### Create Release
When locating artifacts for the various projects, the SHA used to build the artifact is used for the release tag
If all projects are not available with the same SHA, this error is thrown: **The build selected for release doesn't contain all projects. Please rebuild all projects by manually running the CI/CD workflow and recreate the release.**
There is no longer a hard dependency on the main branch name from Create Release.

### AL-Go Tests
Some unit tests have been added and AL-Go unit tests can now be run directly from VS Code.
Another set of end to end tests have also been added and in the documentation on contributing to AL-Go, you can see how to run these in a local fork or from VS Code.

### LF, UTF8 and JSON
GitHub natively uses LF as line seperator in source files.
In earlier versions of AL-Go for GitHub, many scripts and actions would use CRLF and convert back and forth. Some files were written with UTF8 BOM (Byte Order Mark), other files without and JSON formatting was done using PowerShell 5.1 (which is different from PowerShell 7).
In the latest version, we always use LF as line seperator, UTF8 without BOM and JSON files are written using PowerShell 7. If you have self-hosted runners, you need to ensure that PS7 is installed to make this work.

### Experimental Support
Setting the repo setting "shell" to "pwsh", followed by running Update AL-Go System Files, will cause all PowerShell code to be run using PowerShell 7 instead of PowerShell 5. This functionality is experimental. Please report any issues at https://github.com/microsoft/AL-Go/issues
Setting the repo setting "runs-on" to "Ubuntu-Latest", followed by running Update AL-Go System Files, will cause all non-build jobs to run using Linux. This functionality is experimental. Please report any issues at https://github.com/microsoft/AL-Go/issues

## v2.2

### Enhancements
- Container Event log is added as a build artifact if builds or tests are failing

### Issues
- Issue #280 Overflow error when test result summary was too big
- Issue #282, 292 AL-Go for GitHub causes GitHub to issue warnings
- Issue #273 Potential security issue in Pull Request Handler in Open Source repositories
- Issue #303 PullRequestHandler fails on added files
- Issue #299 Multi-project repositories build all projects on Pull Requests
- Issue #291 Issues with new Pull Request Handler 
- Issue #287 AL-Go pipeline fails in ReadSettings step

### Changes
- VersioningStrategy 1 is no longer supported. GITHUB_ID has changed behavior (Issue #277)

## v2.1

### Issues
- Issue #233 AL-Go for GitHub causes GitHub to issue warnings
- Issue #244 Give error if AZURE_CREDENTIALS contains line breaks

### Changes
- New workflow: PullRequestHandler to handle all Pull Requests and pass control safely to CI/CD
- Changes to yaml files, PowerShell scripts and codeowners files are not permitted from fork Pull Requests
- Test Results summary (and failed tests) are now displayed directly in the CI/CD workflow and in the Pull Request Check

### Continuous Delivery
- Proof Of Concept Delivery to GitHub Packages and Nuget
